### PR TITLE
feat: automated hall sync, Google Maps, closed hall tracking

### DIFF
--- a/.github/workflows/update-halls.yml
+++ b/.github/workflows/update-halls.yml
@@ -1,0 +1,58 @@
+name: Update boulder halls
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday 09:00 UTC
+  workflow_dispatch:       # Manual trigger from GitHub UI
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-halls:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Update halls from pofzak.nl
+        run: npm run update-halls
+        env:
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+
+      - name: Open PR if halls.json changed
+        run: |
+          if git diff --quiet src/halls.json; then
+            echo "No changes to halls.json — nothing to do."
+            exit 0
+          fi
+
+          BRANCH="auto/update-halls-$(date +%Y%m%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add src/halls.json
+          git commit -m "chore: auto-update boulder halls from pofzak.nl"
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --title "chore: auto-update boulder halls" \
+            --body "Automated weekly sync from [pofzak.nl](https://pofzak.nl/overzicht-alle-boulderhallen-nederland/). Review the diff before merging — new halls or closed/reopened halls may need attention." \
+            --base main
+
+          # Enable auto-merge: PR merges automatically once all required checks pass.
+          # For this to wait for the Vercel deploy check, enable branch protection on
+          # main (Settings → Branches → Require status checks before merging) and add
+          # the Vercel check name (e.g. "Vercel – Preview" or "vercel/preview") there.
+          gh pr merge --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
-        "cheerio": "^1.2.0"
+        "cheerio": "^1.2.0",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -566,15 +567,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.7.tgz",
-      "integrity": "sha512-rJJbIdJB/RQr2F1nylZr/PJzamvNNhfr3brdKP6s/GW850jbtR70QlSfFselvIBbcPUOlQwBakexjFzqLzF6pg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.7.tgz",
-      "integrity": "sha512-b2wWIE8sABdyafc4IM8r5Y/dS6kD80JRtOGrUiKTsACFQfWWgUQ2NwoUX1yjFMXVsAwcQeNpnucF2ZrujsBBPg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -588,9 +589,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.7.tgz",
-      "integrity": "sha512-zcnVaaZulS1WL0Ss38R5Q6D2gz7MtBu8GZLPfK+73D/hp4GFMrC2sudLky1QibfV7h6RJBJs/gOFvYP0X7UVlQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -604,11 +605,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.7.tgz",
-      "integrity": "sha512-2ant89Lux/Q3VyC8vNVg7uBaFVP9SwoK2jJOOR0L8TQnX8CAYnh4uctAScy2Hwj2dgjVHqHLORQZJ2wH6VxhSQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -620,11 +624,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.7.tgz",
-      "integrity": "sha512-uufcze7LYv0FQg9GnNeZ3/whYfo+1Q3HnQpm16o6Uyi0OVzLlk2ZWoY7j07KADZFY8qwDbsmFnMQP3p3+Ftprw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -636,11 +643,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.7.tgz",
-      "integrity": "sha512-KWVf2gxYvHtvuT+c4MBOGxuse5TD7DsMFYSxVxRBnOzok/xryNeQSjXgxSv9QpIVlaGzEn/pIuI6Koosx8CGWA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -652,11 +662,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.7.tgz",
-      "integrity": "sha512-HguhaGwsGr1YAGs68uRKc4aGWxLET+NevJskOcCAwXbwj0fYX0RgZW2gsOCzr9S11CSQPIkxmoSbuVaBp4Z3dA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -668,9 +681,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.7.tgz",
-      "integrity": "sha512-S0n3KrDJokKTeFyM/vGGGR8+pCmXYrjNTk2ZozOL1C/JFdfUIL9O1ATaJOl5r2POe56iRChbsszrjMAdWSv7kQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -684,9 +697,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.7.tgz",
-      "integrity": "sha512-mwgtg8CNZGYm06LeEd+bNnOUfwOyNem/rOiP14Lsz+AnUY92Zq/LXwtebtUiaeVkhbroRCQ0c8GlR4UT1U+0yg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -2380,9 +2393,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -2453,12 +2466,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.7.tgz",
-      "integrity": "sha512-WM0L7WrSvKwoLegLYr6V+mz+RIofqQgVAfHhMp9a88ms0cFX8iX9ew+snpWlSBwpkURJOUdvCEt3uLl3NNzvWg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.7",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -2472,15 +2485,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.7",
-        "@next/swc-darwin-x64": "16.1.7",
-        "@next/swc-linux-arm64-gnu": "16.1.7",
-        "@next/swc-linux-arm64-musl": "16.1.7",
-        "@next/swc-linux-x64-gnu": "16.1.7",
-        "@next/swc-linux-x64-musl": "16.1.7",
-        "@next/swc-win32-arm64-msvc": "16.1.7",
-        "@next/swc-win32-x64-msvc": "16.1.7",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -2503,34 +2516,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/nth-check": {
@@ -2666,14 +2651,43 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/pretty-format": {
@@ -3107,6 +3121,20 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/uncontrollable": {
       "version": "7.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,15 +11,17 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "@vis.gl/react-google-maps": "^1.8.3",
         "bootstrap": "^5.3.2",
         "bootstrap-icons": "^1.11.3",
-        "leaflet": "^1.9.4",
         "next": "^16.1.7",
         "react": "^18.2.0",
         "react-bootstrap": "^2.10.2",
         "react-dom": "^18.2.0",
-        "react-leaflet": "^4.2.1",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "cheerio": "^1.2.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -67,6 +69,15 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-2.0.2.tgz",
+      "integrity": "sha512-bKVuTqatS8Jven5aFqVB7rCHF1VFEzpzyi0ruzO0GUR+A7m9oMqMgtnmpANj7kMYEvvhty8Fk7TnJ1MKjWHu+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/google.maps": "^3.53.1"
       }
     },
     "node_modules/@img/colour": {
@@ -711,16 +722,6 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
-    "node_modules/@react-leaflet/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
-      "peerDependencies": {
-        "leaflet": "^1.9.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
     "node_modules/@restart/hooks": {
       "version": "0.4.16",
       "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
@@ -1076,6 +1077,12 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
     },
+    "node_modules/@types/google.maps": {
+      "version": "3.64.0",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.64.0.tgz",
+      "integrity": "sha512-dN0H6tB4lgLQLovcbPXFYYOEV41TpyyJghzb5jrzjB96FZmjeOghevVdC+BMGd6YqyCqXaggyEtqRXLRjzCBZA==",
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -1400,6 +1407,21 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="
     },
+    "node_modules/@vis.gl/react-google-maps": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-google-maps/-/react-google-maps-1.8.3.tgz",
+      "integrity": "sha512-DW7nEuvOJ299DmdBnvGiUARrgS/+sTEO1iJgG9J8YaErZqLoq7S4TJ22f3EjJvR4dti4L4gft43JEK77nnKXDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@googlemaps/js-api-loader": "^2.0.2",
+        "@types/google.maps": "^3.54.10",
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": ">=16.8.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1447,6 +1469,13 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/bootstrap": {
       "version": "5.3.2",
@@ -1555,6 +1584,50 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -1579,6 +1652,36 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -1682,6 +1785,65 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1694,6 +1856,33 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -1744,6 +1933,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -1891,6 +2086,52 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/indent-string": {
@@ -2138,11 +2379,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
-    "node_modules/leaflet": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
-    },
     "node_modules/lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
@@ -2297,6 +2533,19 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2355,6 +2604,59 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/picocolors": {
@@ -2487,19 +2789,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "node_modules/react-leaflet": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
-      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
-      "dependencies": {
-        "@react-leaflet/core": "^2.1.0"
-      },
-      "peerDependencies": {
-        "leaflet": "^1.9.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -2547,6 +2836,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -2826,6 +3122,16 @@
         "react": ">=15.0.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -2843,6 +3149,30 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
       "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "update-halls": "node scripts/update-halls.js"
   },
   "devDependencies": {
-    "cheerio": "^1.2.0"
+    "cheerio": "^1.2.0",
+    "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,19 +6,22 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "@vis.gl/react-google-maps": "^1.8.3",
     "bootstrap": "^5.3.2",
     "bootstrap-icons": "^1.11.3",
-    "leaflet": "^1.9.4",
     "next": "^16.1.7",
     "react": "^18.2.0",
     "react-bootstrap": "^2.10.2",
     "react-dom": "^18.2.0",
-    "react-leaflet": "^4.2.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "npx serve@latest ./build"
+    "start": "npx serve@latest ./build",
+    "update-halls": "node scripts/update-halls.js"
+  },
+  "devDependencies": {
+    "cheerio": "^1.2.0"
   }
 }

--- a/scripts/update-halls.js
+++ b/scripts/update-halls.js
@@ -15,13 +15,6 @@ const HALLS_PATH = path.join(__dirname, '../src/halls.json');
 const POFZAK_URL = 'https://pofzak.nl/overzicht-alle-boulderhallen-nederland/';
 const PLACES_URL = 'https://maps.googleapis.com/maps/api/place/textsearch/json';
 
-// Maps normalized pofzak.nl hall names → canonical names used in halls.json.
-// Add entries here when pofzak.nl uses a different name than what we track
-// (e.g. pre-opening names, rebrands, typos).
-const NAME_OVERRIDES = {
-  'be boulder luchthaven 2026': 'Boulderhal Luchthaven',
-};
-
 function normalize(s) {
   return s.toLowerCase().trim().replace(/[^a-z0-9 ]/g, '').replace(/\s+/g, ' ');
 }
@@ -141,19 +134,8 @@ async function main() {
   }
   console.log(`Scraped ${scraped.length} active halls (red rows excluded)`);
 
-  // Build lookup map, applying name overrides for known renames
   const existingByNorm = new Map(existing.map((h) => [normalize(h.name), h]));
-  const scrapedByNorm = new Map();
-  for (const h of scraped) {
-    const norm = normalize(h.name);
-    const overrideName = NAME_OVERRIDES[norm];
-    if (overrideName) {
-      console.log(`  ~ Name override: "${h.name}" → "${overrideName}"`);
-      scrapedByNorm.set(normalize(overrideName), { ...h, name: overrideName });
-    } else {
-      scrapedByNorm.set(norm, h);
-    }
-  }
+  const scrapedByNorm  = new Map(scraped.map((h) => [normalize(h.name), h]));
 
   // Mark halls no longer on the site as closed; reopen ones that came back
   let closedCount = 0;

--- a/scripts/update-halls.js
+++ b/scripts/update-halls.js
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 // Scrapes pofzak.nl for Dutch boulder halls, geocodes new ones via Google Places,
 // and marks halls that have disappeared as closed. Coordinates for existing halls
-// are never changed (stable by design). Planned/cancelled halls are skipped.
+// are never changed (stable by design).
+//
+// Closed/cancelled rows on pofzak.nl have background-color rgb(255,105,102).
+// Those rows are skipped automatically — no name-pattern filtering needed.
 'use strict';
 
 const fs = require('fs');
@@ -12,26 +15,21 @@ const HALLS_PATH = path.join(__dirname, '../src/halls.json');
 const POFZAK_URL = 'https://pofzak.nl/overzicht-alle-boulderhallen-nederland/';
 const PLACES_URL = 'https://maps.googleapis.com/maps/api/place/textsearch/json';
 
-// Hall names containing these substrings (case-insensitive) are skipped —
-// they indicate planned, cancelled, on-hold, or already-closed halls that
-// pofzak.nl tracks for reference but we don't want in our list.
-const SKIP_KEYWORDS = ['gesloten', 'geannuleerd', 'on hold', 'onbekend'];
-
-// Also skip halls whose name contains a year >= current year in parentheses,
-// indicating a future planned opening: e.g. "Foo (Luchthaven 2026)".
-const SKIP_YEAR_RE = /\(.*?(\d{4}).*?\)/;
-const CURRENT_YEAR = new Date().getFullYear();
+// Maps normalized pofzak.nl hall names → canonical names used in halls.json.
+// Add entries here when pofzak.nl uses a different name than what we track
+// (e.g. pre-opening names, rebrands, typos).
+const NAME_OVERRIDES = {
+  'be boulder luchthaven 2026': 'Boulderhal Luchthaven',
+};
 
 function normalize(s) {
   return s.toLowerCase().trim().replace(/[^a-z0-9 ]/g, '').replace(/\s+/g, ' ');
 }
 
-function shouldSkip(hall) {
-  const lower = hall.name.toLowerCase();
-  if (SKIP_KEYWORDS.some((kw) => lower.includes(kw))) return true;
-  const m = hall.name.match(SKIP_YEAR_RE);
-  if (m && parseInt(m[1], 10) >= CURRENT_YEAR) return true;
-  return false;
+function isRedRow($, row) {
+  // pofzak.nl marks closed/cancelled rows by adding class "bg-ff6966" to the <td> cells
+  const firstCell = $(row).find('td').first();
+  return firstCell.hasClass('bg-ff6966');
 }
 
 async function scrapeHalls() {
@@ -59,6 +57,9 @@ async function scrapeHalls() {
     const pi = provIdx >= 0 ? provIdx : 2;
 
     $(table).find('tbody tr').each((_, row) => {
+      // Skip rows with red background — these are closed/cancelled/on-hold halls
+      if (isRedRow($, row)) return;
+
       const cells = $(row).find('td');
       if (cells.length < 3) return;
 
@@ -95,10 +96,6 @@ async function geocode(name, city, apiKey) {
 
 async function main() {
   const apiKey = process.env.GOOGLE_MAPS_API_KEY;
-  if (!apiKey) {
-    console.error('GOOGLE_MAPS_API_KEY is not set. Aborting.');
-    process.exit(1);
-  }
 
   // Load existing halls and ensure new fields exist (idempotent migration)
   const existing = JSON.parse(fs.readFileSync(HALLS_PATH, 'utf-8'));
@@ -108,24 +105,26 @@ async function main() {
   });
 
   // Re-geocode halls with imprecise coordinates
-  const needsRegeocoding = existing.filter(
-    (h) => h.geocodeSource === 'city-fallback' || h.geocodeSource === 'failed'
-  );
-  if (needsRegeocoding.length > 0) {
-    console.log(`Re-geocoding ${needsRegeocoding.length} hall(s) with imprecise coordinates...`);
-    for (const hall of needsRegeocoding) {
-      try {
-        const result = await geocode(hall.name, hall.city, apiKey);
-        if (result) {
-          console.log(`  ✓ ${hall.name}: (${result.lat.toFixed(4)}, ${result.lon.toFixed(4)})`);
-          hall.latitude = result.lat;
-          hall.longitude = result.lon;
-          hall.geocodeSource = 'google-places';
-        } else {
-          console.log(`  ~ ${hall.name}: no result, keeping existing coords`);
+  if (apiKey) {
+    const needsRegeocoding = existing.filter(
+      (h) => h.geocodeSource === 'city-fallback' || h.geocodeSource === 'failed'
+    );
+    if (needsRegeocoding.length > 0) {
+      console.log(`Re-geocoding ${needsRegeocoding.length} hall(s) with imprecise coordinates...`);
+      for (const hall of needsRegeocoding) {
+        try {
+          const result = await geocode(hall.name, hall.city, apiKey);
+          if (result) {
+            console.log(`  ✓ ${hall.name}: (${result.lat.toFixed(4)}, ${result.lon.toFixed(4)})`);
+            hall.latitude = result.lat;
+            hall.longitude = result.lon;
+            hall.geocodeSource = 'google-places';
+          } else {
+            console.log(`  ~ ${hall.name}: no result, keeping existing coords`);
+          }
+        } catch (err) {
+          console.warn(`  ! ${hall.name}: ${err.message}`);
         }
-      } catch (err) {
-        console.warn(`  ! ${hall.name}: ${err.message}`);
       }
     }
   }
@@ -138,20 +137,23 @@ async function main() {
   } catch (err) {
     console.error(`Scrape failed: ${err.message}`);
     fs.writeFileSync(HALLS_PATH, JSON.stringify(existing, null, 2) + '\n');
-    console.log(`Wrote migrated fields for ${existing.length} halls (scrape skipped).`);
     process.exit(0);
   }
+  console.log(`Scraped ${scraped.length} active halls (red rows excluded)`);
 
-  // Filter out planned/cancelled halls
-  const skipped = scraped.filter(shouldSkip);
-  const active = scraped.filter((h) => !shouldSkip(h));
-  if (skipped.length) {
-    console.log(`Skipped ${skipped.length} planned/cancelled: ${skipped.map((h) => h.name).join(', ')}`);
-  }
-  console.log(`Scraped ${active.length} active halls`);
-
+  // Build lookup map, applying name overrides for known renames
   const existingByNorm = new Map(existing.map((h) => [normalize(h.name), h]));
-  const scrapedByNorm = new Map(active.map((h) => [normalize(h.name), h]));
+  const scrapedByNorm = new Map();
+  for (const h of scraped) {
+    const norm = normalize(h.name);
+    const overrideName = NAME_OVERRIDES[norm];
+    if (overrideName) {
+      console.log(`  ~ Name override: "${h.name}" → "${overrideName}"`);
+      scrapedByNorm.set(normalize(overrideName), { ...h, name: overrideName });
+    } else {
+      scrapedByNorm.set(norm, h);
+    }
+  }
 
   // Mark halls no longer on the site as closed; reopen ones that came back
   let closedCount = 0;
@@ -168,7 +170,7 @@ async function main() {
       reopenedCount++;
       console.log(`  ~ Reopened: ${hall.name}`);
     }
-    // Intentionally not propagating province from scrape — pofzak.nl data has errors.
+    // Intentionally not propagating province — pofzak.nl data has errors.
   }
 
   // Geocode and add new halls
@@ -177,6 +179,17 @@ async function main() {
     if (existingByNorm.has(norm)) continue;
 
     console.log(`  + New hall: ${s.name} (${s.city}) — geocoding...`);
+
+    if (!apiKey) {
+      console.error('    GOOGLE_MAPS_API_KEY not set — cannot geocode. Set it and re-run.');
+      newHalls.push({
+        name: s.name, city: s.city, province: s.province,
+        latitude: 0, longitude: 0,
+        visited: false, rating: 'N/A', closed: false, geocodeSource: 'failed',
+      });
+      continue;
+    }
+
     let coords = null;
     try {
       coords = await geocode(s.name, s.city, apiKey);
@@ -191,14 +204,9 @@ async function main() {
     }
 
     newHalls.push({
-      name: s.name,
-      city: s.city,
-      province: s.province,
-      latitude: coords?.lat ?? 0,
-      longitude: coords?.lon ?? 0,
-      visited: false,
-      rating: 'N/A',
-      closed: false,
+      name: s.name, city: s.city, province: s.province,
+      latitude: coords?.lat ?? 0, longitude: coords?.lon ?? 0,
+      visited: false, rating: 'N/A', closed: false,
       geocodeSource: coords ? 'google-places' : 'failed',
     });
   }

--- a/scripts/update-halls.js
+++ b/scripts/update-halls.js
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+// Scrapes pofzak.nl for Dutch boulder halls, geocodes new ones via Google Places,
+// and marks halls that have disappeared as closed. Coordinates for existing halls
+// are never changed (stable by design). Planned/cancelled halls are skipped.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { load } = require('cheerio');
+
+const HALLS_PATH = path.join(__dirname, '../src/halls.json');
+const POFZAK_URL = 'https://pofzak.nl/overzicht-alle-boulderhallen-nederland/';
+const PLACES_URL = 'https://maps.googleapis.com/maps/api/place/textsearch/json';
+
+// Hall names containing these substrings (case-insensitive) are skipped —
+// they indicate planned, cancelled, on-hold, or already-closed halls that
+// pofzak.nl tracks for reference but we don't want in our list.
+const SKIP_KEYWORDS = ['gesloten', 'geannuleerd', 'on hold', 'onbekend'];
+
+// Also skip halls whose name contains a year >= current year in parentheses,
+// indicating a future planned opening: e.g. "Foo (Luchthaven 2026)".
+const SKIP_YEAR_RE = /\(.*?(\d{4}).*?\)/;
+const CURRENT_YEAR = new Date().getFullYear();
+
+function normalize(s) {
+  return s.toLowerCase().trim().replace(/[^a-z0-9 ]/g, '').replace(/\s+/g, ' ');
+}
+
+function shouldSkip(hall) {
+  const lower = hall.name.toLowerCase();
+  if (SKIP_KEYWORDS.some((kw) => lower.includes(kw))) return true;
+  const m = hall.name.match(SKIP_YEAR_RE);
+  if (m && parseInt(m[1], 10) >= CURRENT_YEAR) return true;
+  return false;
+}
+
+async function scrapeHalls() {
+  const res = await fetch(POFZAK_URL, {
+    headers: { 'User-Agent': 'BoulderHallsNL-updater/1.0 (personal site; contact via github)' },
+  });
+  if (!res.ok) throw new Error(`Failed to fetch ${POFZAK_URL}: ${res.status}`);
+
+  const html = await res.text();
+  const $ = load(html);
+  const halls = [];
+
+  $('table').each((_, table) => {
+    const headers = [];
+    $(table).find('thead th, thead td, tr:first-child th, tr:first-child td').each((_, th) => {
+      headers.push($(th).text().trim().toLowerCase());
+    });
+
+    const nameIdx = headers.findIndex((h) => h.includes('naam') || h.includes('hal'));
+    const cityIdx = headers.findIndex((h) => h.includes('stad') || h.includes('plaats') || h.includes('gemeente'));
+    const provIdx = headers.findIndex((h) => h.includes('provin'));
+
+    const ni = nameIdx >= 0 ? nameIdx : 0;
+    const ci = cityIdx >= 0 ? cityIdx : 1;
+    const pi = provIdx >= 0 ? provIdx : 2;
+
+    $(table).find('tbody tr').each((_, row) => {
+      const cells = $(row).find('td');
+      if (cells.length < 3) return;
+
+      const name = $(cells[ni]).text().trim();
+      const city = $(cells[ci]).text().trim();
+      const province = $(cells[pi]).text().trim();
+
+      if (name && city && province) {
+        halls.push({ name, city, province });
+      }
+    });
+
+    if (halls.length > 0) return false;
+  });
+
+  return halls;
+}
+
+async function geocode(name, city, apiKey) {
+  const query = `${name} ${city} Netherlands`;
+  const url = `${PLACES_URL}?query=${encodeURIComponent(query)}&key=${apiKey}&language=nl&region=nl`;
+
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`Google Places error: ${r.status}`);
+  const data = await r.json();
+
+  if (data.status === 'OK' && data.results.length > 0) {
+    const loc = data.results[0].geometry.location;
+    return { lat: loc.lat, lon: loc.lng };
+  }
+  if (data.status === 'ZERO_RESULTS') return null;
+  throw new Error(`Google Places API error: ${data.status} — ${data.error_message || ''}`);
+}
+
+async function main() {
+  const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+  if (!apiKey) {
+    console.error('GOOGLE_MAPS_API_KEY is not set. Aborting.');
+    process.exit(1);
+  }
+
+  // Load existing halls and ensure new fields exist (idempotent migration)
+  const existing = JSON.parse(fs.readFileSync(HALLS_PATH, 'utf-8'));
+  existing.forEach((h) => {
+    if (h.closed === undefined) h.closed = false;
+    if (h.geocodeSource === undefined) h.geocodeSource = 'manual';
+  });
+
+  // Re-geocode halls with imprecise coordinates
+  const needsRegeocoding = existing.filter(
+    (h) => h.geocodeSource === 'city-fallback' || h.geocodeSource === 'failed'
+  );
+  if (needsRegeocoding.length > 0) {
+    console.log(`Re-geocoding ${needsRegeocoding.length} hall(s) with imprecise coordinates...`);
+    for (const hall of needsRegeocoding) {
+      try {
+        const result = await geocode(hall.name, hall.city, apiKey);
+        if (result) {
+          console.log(`  ✓ ${hall.name}: (${result.lat.toFixed(4)}, ${result.lon.toFixed(4)})`);
+          hall.latitude = result.lat;
+          hall.longitude = result.lon;
+          hall.geocodeSource = 'google-places';
+        } else {
+          console.log(`  ~ ${hall.name}: no result, keeping existing coords`);
+        }
+      } catch (err) {
+        console.warn(`  ! ${hall.name}: ${err.message}`);
+      }
+    }
+  }
+
+  // Scrape pofzak.nl
+  console.log(`\nFetching ${POFZAK_URL}...`);
+  let scraped;
+  try {
+    scraped = await scrapeHalls();
+  } catch (err) {
+    console.error(`Scrape failed: ${err.message}`);
+    fs.writeFileSync(HALLS_PATH, JSON.stringify(existing, null, 2) + '\n');
+    console.log(`Wrote migrated fields for ${existing.length} halls (scrape skipped).`);
+    process.exit(0);
+  }
+
+  // Filter out planned/cancelled halls
+  const skipped = scraped.filter(shouldSkip);
+  const active = scraped.filter((h) => !shouldSkip(h));
+  if (skipped.length) {
+    console.log(`Skipped ${skipped.length} planned/cancelled: ${skipped.map((h) => h.name).join(', ')}`);
+  }
+  console.log(`Scraped ${active.length} active halls`);
+
+  const existingByNorm = new Map(existing.map((h) => [normalize(h.name), h]));
+  const scrapedByNorm = new Map(active.map((h) => [normalize(h.name), h]));
+
+  // Mark halls no longer on the site as closed; reopen ones that came back
+  let closedCount = 0;
+  let reopenedCount = 0;
+  for (const [norm, hall] of existingByNorm) {
+    if (!scrapedByNorm.has(norm)) {
+      if (!hall.closed) {
+        hall.closed = true;
+        closedCount++;
+        console.log(`  ! Marked closed: ${hall.name}`);
+      }
+    } else if (hall.closed) {
+      hall.closed = false;
+      reopenedCount++;
+      console.log(`  ~ Reopened: ${hall.name}`);
+    }
+    // Intentionally not propagating province from scrape — pofzak.nl data has errors.
+  }
+
+  // Geocode and add new halls
+  const newHalls = [];
+  for (const [norm, s] of scrapedByNorm) {
+    if (existingByNorm.has(norm)) continue;
+
+    console.log(`  + New hall: ${s.name} (${s.city}) — geocoding...`);
+    let coords = null;
+    try {
+      coords = await geocode(s.name, s.city, apiKey);
+    } catch (err) {
+      console.error(`    Failed: ${err.message}`);
+    }
+
+    if (coords) {
+      console.log(`    → (${coords.lat.toFixed(4)}, ${coords.lon.toFixed(4)})`);
+    } else {
+      console.log(`    → not found, coordinates need manual entry`);
+    }
+
+    newHalls.push({
+      name: s.name,
+      city: s.city,
+      province: s.province,
+      latitude: coords?.lat ?? 0,
+      longitude: coords?.lon ?? 0,
+      visited: false,
+      rating: 'N/A',
+      closed: false,
+      geocodeSource: coords ? 'google-places' : 'failed',
+    });
+  }
+
+  const updated = [...existing, ...newHalls];
+  fs.writeFileSync(HALLS_PATH, JSON.stringify(updated, null, 2) + '\n');
+
+  console.log(`\nDone. ${updated.length} halls total.`);
+  if (closedCount)   console.log(`  ${closedCount} marked as closed`);
+  if (reopenedCount) console.log(`  ${reopenedCount} reopened`);
+  if (newHalls.length) {
+    console.log(`  ${newHalls.length} new halls added`);
+    const failed = newHalls.filter((h) => h.geocodeSource === 'failed');
+    if (failed.length) {
+      console.log(`  ⚠ ${failed.length} hall(s) need manual coordinates:`);
+      failed.forEach((h) => console.log(`    - ${h.name} (${h.city})`));
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/App.js
+++ b/src/App.js
@@ -226,21 +226,30 @@ function App() {
 
   return (
     <div className="App">
-      <div className={"container py-5"}>
-        <h1 className={"text-center mb-4"}>Boulderhallen</h1>
-        <div className={"row justify-content-center"}>
+      <div className="container">
+        <header className="site-header">
+          <h1 className="site-title">Boulderhallen</h1>
+          <p className="site-subtitle">
+            <strong>{visitedCount}</strong> van {halls.length} hallen bezocht
+          </p>
+        </header>
+        <div className="row justify-content-center">
           <Warning
             message={"Je hebt geen toegang gegeven voor je locatie. Herlaad de pagina met toegang om ook de afstanden te zien."}
             show={showWarning}
             onClose={() => setShowWarning(false)}
           />
-          <div className={"col-md-8"}>
-            {showMap && <Map
-              key={mapKey}
-              data={displayedHalls}
-              coords={myCoordinates}
-              isDark={isDark}
-            />}
+          <div className="col-lg-10 col-xl-9">
+            {showMap && (
+              <div className="map-wrapper">
+                <Map
+                  key={mapKey}
+                  data={displayedHalls}
+                  coords={myCoordinates}
+                  isDark={isDark}
+                />
+              </div>
+            )}
             <Search
               showVisited={showVisited}
               showMap={toggleMapVisibility}
@@ -262,6 +271,7 @@ function App() {
       </div>
     </div>
   );
+
 }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -24,6 +24,37 @@ function App() {
   const [showMap, setShowMap] = useState(false);
   const [locationSet, setLocationSet] = useState(false);
   const [showClosed, setShowClosed] = useState(false);
+  const [isDark, setIsDark] = useState(() => {
+    try {
+      const saved = localStorage.getItem('theme');
+      if (saved !== null) return saved === 'dark';
+    } catch {}
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
+
+  // ---------------------- Theme ---------------------- //
+  useEffect(() => {
+    document.documentElement.setAttribute('data-bs-theme', isDark ? 'dark' : 'light');
+  }, [isDark]);
+
+  // Follow system preference when the user hasn't manually overridden
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e) => {
+      try { if (localStorage.getItem('theme') !== null) return; } catch {}
+      setIsDark(e.matches);
+    };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  const toggleTheme = () => {
+    setIsDark(prev => {
+      const next = !prev;
+      try { localStorage.setItem('theme', next ? 'dark' : 'light'); } catch {}
+      return next;
+    });
+  };
 
   // ---------------------- Basic set-up ---------------------- //
   useEffect(() => {
@@ -208,6 +239,7 @@ function App() {
               key={mapKey}
               data={displayedHalls}
               coords={myCoordinates}
+              isDark={isDark}
             />}
             <Search
               showVisited={showVisited}
@@ -218,6 +250,8 @@ function App() {
               showClosed={showClosed}
               toggleShowClosed={toggleShowClosed}
               closedCount={halls.filter(h => h.closed).length}
+              isDark={isDark}
+              toggleTheme={toggleTheme}
             />
             <Halls
               halls={displayedHalls}

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, {useState, useEffect} from 'react';
 import 'bootstrap/dist/css/bootstrap.min.css';
+import "bootstrap-icons/font/bootstrap-icons.css";
 import Halls from './components/Halls';
 import Search from './components/Search';
 import Warning from './components/Warning';
@@ -19,11 +20,11 @@ function App() {
     province: 'asc',
     distance: 'asc',
     rating: 'asc',
-    visited: false
+    visited: false,
+    closed: false,
   });
   const [showMap, setShowMap] = useState(false);
   const [locationSet, setLocationSet] = useState(false);
-  const [showClosed, setShowClosed] = useState(false);
   const [isDark, setIsDark] = useState(() => {
     try {
       const saved = localStorage.getItem('theme');
@@ -37,7 +38,6 @@ function App() {
     document.documentElement.setAttribute('data-bs-theme', isDark ? 'dark' : 'light');
   }, [isDark]);
 
-  // Follow system preference when the user hasn't manually overridden
   useEffect(() => {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     const handler = (e) => {
@@ -47,6 +47,11 @@ function App() {
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);
   }, []);
+
+  // Remount the map when the theme changes so colorScheme applies reliably
+  useEffect(() => {
+    if (showMap) setMapKey(k => k + 1);
+  }, [isDark]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const toggleTheme = () => {
     setIsDark(prev => {
@@ -59,7 +64,7 @@ function App() {
   // ---------------------- Basic set-up ---------------------- //
   useEffect(() => {
     setHalls(hallsData);
-    setDisplayedHalls(hallsData.filter(h => !h.closed));
+    setDisplayedHalls(hallsData);
     setVisitedCount(hallsData.filter(hall => hall.visited).length);
 
     const showPosition = (position) => {
@@ -75,9 +80,10 @@ function App() {
       setLocationSet(true);
     };
 
-    navigator.geolocation ? navigator.geolocation.getCurrentPosition(showPosition, showError) : console.error("Geolocation is not supported by this browser.");
+    navigator.geolocation
+      ? navigator.geolocation.getCurrentPosition(showPosition, showError)
+      : console.error("Geolocation is not supported by this browser.");
   }, []);
-
 
   useEffect(() => {
     if (!locationSet) {
@@ -104,21 +110,18 @@ function App() {
     }
   }, [locationSet]);
 
-
   useEffect(() => {
     if (!halls.length) return;
-    const base = halls.filter(h => showClosed || !h.closed);
     if (myCoordinates) {
-      const updatedHalls = base.map(hall => ({
+      const updatedHalls = halls.map(hall => ({
         ...hall,
         distance: calculateDistance(myCoordinates.latitude, myCoordinates.longitude, hall.latitude, hall.longitude)
       }));
       sortByDistanceInitial(updatedHalls);
     } else {
-      setDisplayedHalls(base);
+      setDisplayedHalls(halls);
     }
-  }, [halls, myCoordinates, showClosed]);
-
+  }, [halls, myCoordinates]);
 
   // ---------------------- Sorting functions ---------------------- //
   const sortByDistanceInitial = (hallsWithDistance) => {
@@ -145,19 +148,18 @@ function App() {
   };
 
   const showVisited = () => {
-    const base = halls.filter(h => showClosed || !h.closed);
     if (sortState.visited) {
       if (myCoordinates) {
-        const hallsWithDistance = base.map(hall => ({
+        const hallsWithDistance = halls.map(hall => ({
           ...hall,
           distance: calculateDistance(myCoordinates.latitude, myCoordinates.longitude, hall.latitude, hall.longitude)
         }));
         sortByDistanceInitial(hallsWithDistance);
       } else {
-        setDisplayedHalls(base);
+        setDisplayedHalls(halls);
       }
     } else {
-      const visitedHalls = base.filter(hall => hall.visited);
+      const visitedHalls = halls.filter(hall => hall.visited);
       if (myCoordinates) {
         const hallsWithDistance = visitedHalls.map(hall => ({
           ...hall,
@@ -170,19 +172,45 @@ function App() {
     }
     setSortState(prevState => ({
       ...prevState,
-      visited: !prevState.visited
+      visited: !prevState.visited,
+      closed: false,
     }));
-  }
+  };
 
-  const toggleShowClosed = () => setShowClosed(prev => !prev);
-
+  const showOnlyClosed = () => {
+    if (sortState.closed) {
+      if (myCoordinates) {
+        const hallsWithDistance = halls.map(hall => ({
+          ...hall,
+          distance: calculateDistance(myCoordinates.latitude, myCoordinates.longitude, hall.latitude, hall.longitude)
+        }));
+        sortByDistanceInitial(hallsWithDistance);
+      } else {
+        setDisplayedHalls(halls);
+      }
+    } else {
+      const closedHalls = halls.filter(hall => hall.closed);
+      if (myCoordinates) {
+        const hallsWithDistance = closedHalls.map(hall => ({
+          ...hall,
+          distance: calculateDistance(myCoordinates.latitude, myCoordinates.longitude, hall.latitude, hall.longitude)
+        }));
+        sortByDistanceInitial(hallsWithDistance);
+      } else {
+        setDisplayedHalls(closedHalls);
+      }
+    }
+    setSortState(prevState => ({
+      ...prevState,
+      closed: !prevState.closed,
+      visited: false,
+    }));
+  };
 
   const toggleMapVisibility = () => {
     setShowMap(prevShow => {
       const nextShow = !prevShow;
-      if (nextShow) {
-        setMapKey(prevKey => prevKey + 1);
-      }
+      if (nextShow) setMapKey(prevKey => prevKey + 1);
       return nextShow;
     });
   };
@@ -190,7 +218,6 @@ function App() {
   // ---------------------- Helper functions ---------------------- //
   const calculateDistance = (lat1, lon1, lat2, lon2) => {
     if (!lat1 || !lon1 || !lat2 || !lon2) return null;
-
     const toRadians = degree => degree * Math.PI / 180;
     let R = 6371;
     let dLat = toRadians(lat2 - lat1);
@@ -200,19 +227,16 @@ function App() {
       Math.sin(dLon / 2) * Math.sin(dLon / 2);
     let c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
     return R * c;
-  }
+  };
 
   const handleSearchChange = (searchQuery) => {
     const lowerCaseQuery = searchQuery.toLowerCase();
-    const base = halls.filter(h => showClosed || !h.closed);
-
-    const filteredHalls = base.filter(hall =>
+    const filteredHalls = halls.filter(hall =>
       hall.name.toLowerCase().includes(lowerCaseQuery) ||
       hall.city.toLowerCase().includes(lowerCaseQuery) ||
       hall.province.toLowerCase().includes(lowerCaseQuery) ||
       (hall.rating && hall.rating.toString().toLowerCase().includes(lowerCaseQuery))
     );
-
     if (myCoordinates) {
       const hallsWithDistance = filteredHalls.map(hall => ({
         ...hall,
@@ -224,10 +248,19 @@ function App() {
     }
   };
 
+  const closedCount = halls.filter(h => h.closed).length;
+
   return (
     <div className="App">
       <div className="container">
         <header className="site-header">
+          <button
+            className="btn btn-outline-secondary theme-toggle"
+            onClick={toggleTheme}
+            title={isDark ? 'Lichtmodus' : 'Donkermodus'}
+          >
+            <i className={`bi ${isDark ? 'bi-sun-fill' : 'bi-moon-fill'}`} />
+          </button>
           <h1 className="site-title">Boulderhallen</h1>
           <p className="site-subtitle">
             <strong>{visitedCount}</strong> van {halls.length} hallen bezocht
@@ -253,15 +286,14 @@ function App() {
             <Search
               showVisited={showVisited}
               visitedFiltered={sortState.visited}
+              showOnlyClosed={showOnlyClosed}
+              closedFiltered={sortState.closed}
               showMap={toggleMapVisibility}
+              mapVisible={showMap}
               visitedCount={visitedCount}
               hallCount={displayedHalls.length}
               onSearchChange={handleSearchChange}
-              showClosed={showClosed}
-              toggleShowClosed={toggleShowClosed}
-              closedCount={halls.filter(h => h.closed).length}
-              isDark={isDark}
-              toggleTheme={toggleTheme}
+              closedCount={closedCount}
             />
             <Halls
               halls={displayedHalls}
@@ -272,7 +304,6 @@ function App() {
       </div>
     </div>
   );
-
 }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -23,11 +23,12 @@ function App() {
   });
   const [showMap, setShowMap] = useState(false);
   const [locationSet, setLocationSet] = useState(false);
+  const [showClosed, setShowClosed] = useState(false);
 
   // ---------------------- Basic set-up ---------------------- //
   useEffect(() => {
     setHalls(hallsData);
-    setDisplayedHalls(hallsData);
+    setDisplayedHalls(hallsData.filter(h => !h.closed));
     setVisitedCount(hallsData.filter(hall => hall.visited).length);
 
     const showPosition = (position) => {
@@ -74,14 +75,18 @@ function App() {
 
 
   useEffect(() => {
+    if (!halls.length) return;
+    const base = halls.filter(h => showClosed || !h.closed);
     if (myCoordinates) {
-      const updatedHalls = halls.map(hall => ({
+      const updatedHalls = base.map(hall => ({
         ...hall,
         distance: calculateDistance(myCoordinates.latitude, myCoordinates.longitude, hall.latitude, hall.longitude)
       }));
       sortByDistanceInitial(updatedHalls);
+    } else {
+      setDisplayedHalls(base);
     }
-  }, [halls, myCoordinates]);
+  }, [halls, myCoordinates, showClosed]);
 
 
   // ---------------------- Sorting functions ---------------------- //
@@ -109,18 +114,19 @@ function App() {
   };
 
   const showVisited = () => {
+    const base = halls.filter(h => showClosed || !h.closed);
     if (sortState.visited) {
       if (myCoordinates) {
-        const hallsWithDistance = halls.map(hall => ({
+        const hallsWithDistance = base.map(hall => ({
           ...hall,
           distance: calculateDistance(myCoordinates.latitude, myCoordinates.longitude, hall.latitude, hall.longitude)
         }));
         sortByDistanceInitial(hallsWithDistance);
       } else {
-        setDisplayedHalls(halls);
+        setDisplayedHalls(base);
       }
     } else {
-      const visitedHalls = halls.filter(hall => hall.visited);
+      const visitedHalls = base.filter(hall => hall.visited);
       if (myCoordinates) {
         const hallsWithDistance = visitedHalls.map(hall => ({
           ...hall,
@@ -136,6 +142,8 @@ function App() {
       visited: !prevState.visited
     }));
   }
+
+  const toggleShowClosed = () => setShowClosed(prev => !prev);
 
 
   const toggleMapVisibility = () => {
@@ -165,8 +173,9 @@ function App() {
 
   const handleSearchChange = (searchQuery) => {
     const lowerCaseQuery = searchQuery.toLowerCase();
+    const base = halls.filter(h => showClosed || !h.closed);
 
-    const filteredHalls = halls.filter(hall =>
+    const filteredHalls = base.filter(hall =>
       hall.name.toLowerCase().includes(lowerCaseQuery) ||
       hall.city.toLowerCase().includes(lowerCaseQuery) ||
       hall.province.toLowerCase().includes(lowerCaseQuery) ||
@@ -206,6 +215,9 @@ function App() {
               visitedCount={visitedCount}
               hallCount={displayedHalls.length}
               onSearchChange={handleSearchChange}
+              showClosed={showClosed}
+              toggleShowClosed={toggleShowClosed}
+              closedCount={halls.filter(h => h.closed).length}
             />
             <Halls
               halls={displayedHalls}

--- a/src/App.js
+++ b/src/App.js
@@ -252,6 +252,7 @@ function App() {
             )}
             <Search
               showVisited={showVisited}
+              visitedFiltered={sortState.visited}
               showMap={toggleMapVisibility}
               visitedCount={visitedCount}
               hallCount={displayedHalls.length}

--- a/src/App.js
+++ b/src/App.js
@@ -25,6 +25,8 @@ function App() {
   });
   const [showMap, setShowMap] = useState(false);
   const [locationSet, setLocationSet] = useState(false);
+  const [lastSort, setLastSort] = useState({ col: null, dir: null });
+  const [focusRequest, setFocusRequest] = useState(null);
   const [isDark, setIsDark] = useState(() => {
     try {
       const saved = localStorage.getItem('theme');
@@ -141,10 +143,19 @@ function App() {
     });
 
     setDisplayedHalls(sortedHalls);
+    setLastSort({ col: type, dir: sortState[type] });
     setSortState(prevState => ({
       ...prevState,
       [type]: prevState[type] === 'asc' ? 'desc' : 'asc'
     }));
+  };
+
+  const focusHallOnMap = (hall) => {
+    setFocusRequest(prev => ({ hall, seq: (prev?.seq ?? 0) + 1 }));
+    if (!showMap) {
+      setShowMap(true);
+      setMapKey(k => k + 1);
+    }
   };
 
   const showVisited = () => {
@@ -280,6 +291,7 @@ function App() {
                   data={displayedHalls}
                   coords={myCoordinates}
                   isDark={isDark}
+                  focusRequest={focusRequest}
                 />
               </div>
             )}
@@ -298,6 +310,8 @@ function App() {
             <Halls
               halls={displayedHalls}
               sortBy={sortBy}
+              lastSort={lastSort}
+              focusHall={focusHallOnMap}
             />
           </div>
         </div>

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -12,7 +12,11 @@ export const viewport = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body style={{ backgroundColor: '#212529', color: 'white' }}>
+      <head>
+        {/* Runs synchronously before React mounts — prevents theme flash */}
+        <script dangerouslySetInnerHTML={{ __html: `(function(){try{var t=localStorage.getItem('theme');var d=t?t==='dark':window.matchMedia('(prefers-color-scheme: dark)').matches;document.documentElement.setAttribute('data-bs-theme',d?'dark':'light');}catch(e){}})();` }} />
+      </head>
+      <body>
         <div id="root">{children}</div>
       </body>
     </html>

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,5 +1,4 @@
 import '../index.css'
-import 'leaflet/dist/leaflet.css'
 
 export const metadata = {
   title: 'Boulderhallen',

--- a/src/components/Halls.js
+++ b/src/components/Halls.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import "bootstrap-icons/font/bootstrap-icons.css";
 
 const VISITED_BG = '#2f7531';
 const CLOSED_BG  = '#4b5563';
@@ -9,26 +10,38 @@ function rowBg(hall) {
   return 'transparent';
 }
 
-function Halls({ halls, sortBy }) {
+function SortBtn({ label, col, sortBy, lastSort }) {
+  const active = lastSort?.col === col;
+  const arrow  = active ? (lastSort.dir === 'asc' ? ' ↑' : ' ↓') : '';
+  return (
+    <button className="btn" onClick={() => sortBy(col)}>
+      {label}{arrow && <span style={{ opacity: 0.7 }}>{arrow}</span>}
+    </button>
+  );
+}
+
+function Halls({ halls, sortBy, lastSort, focusHall }) {
   return (
     <div className="table-responsive">
       <table className="table table-striped table-hover">
         <thead>
           <tr>
-            <th><button className="btn" onClick={() => sortBy('name')}>Naam</button></th>
-            <th><button className="btn" onClick={() => sortBy('city')}>Stad</button></th>
-            <th><button className="btn" onClick={() => sortBy('province')}>Provincie</button></th>
-            <th><button className="btn" onClick={() => sortBy('distance')}>Afstand</button></th>
-            <th><button className="btn" onClick={() => sortBy('rating')}>Rating</button></th>
+            <th><SortBtn label="Naam"      col="name"     sortBy={sortBy} lastSort={lastSort} /></th>
+            <th><SortBtn label="Stad"      col="city"     sortBy={sortBy} lastSort={lastSort} /></th>
+            <th><SortBtn label="Provincie" col="province" sortBy={sortBy} lastSort={lastSort} /></th>
+            <th><SortBtn label="Afstand"   col="distance" sortBy={sortBy} lastSort={lastSort} /></th>
+            <th><SortBtn label="Rating"    col="rating"   sortBy={sortBy} lastSort={lastSort} /></th>
+            <th style={{ width: 40 }} />
           </tr>
         </thead>
         <tbody>
           {halls.map((hall, index) => {
             const bg = rowBg(hall);
             const hasColoredBg = bg !== 'transparent';
+            const cellStyle = { backgroundColor: bg, color: hasColoredBg ? '#fff' : undefined };
             return (
               <tr key={index}>
-                <td style={{ backgroundColor: bg, color: hasColoredBg ? '#fff' : undefined }}>
+                <td style={cellStyle}>
                   {hall.name}
                   {hall.closed && (
                     <span className="badge bg-secondary ms-2" style={{ fontSize: '0.68em', verticalAlign: 'middle' }}>
@@ -36,12 +49,27 @@ function Halls({ halls, sortBy }) {
                     </span>
                   )}
                 </td>
-                <td style={{ backgroundColor: bg, color: hasColoredBg ? '#fff' : undefined }}>{hall.city}</td>
-                <td style={{ backgroundColor: bg, color: hasColoredBg ? '#fff' : undefined }}>{hall.province}</td>
-                <td style={{ backgroundColor: bg, color: hasColoredBg ? '#fff' : undefined }}>
-                  {hall.distance ? `${hall.distance.toFixed(1)} km` : '—'}
+                <td style={cellStyle}>{hall.city}</td>
+                <td style={cellStyle}>{hall.province}</td>
+                <td style={cellStyle}>{hall.distance ? `${hall.distance.toFixed(1)} km` : '—'}</td>
+                <td style={cellStyle}>{hall.rating}</td>
+                <td style={{ ...cellStyle, textAlign: 'center', padding: '0.4rem' }}>
+                  {!hall.closed && (
+                    <button
+                      className="btn p-1"
+                      style={{
+                        color: hasColoredBg ? 'rgba(255,255,255,0.85)' : 'var(--bs-secondary-color)',
+                        background: 'transparent',
+                        border: 'none',
+                        lineHeight: 1,
+                      }}
+                      onClick={() => focusHall(hall)}
+                      title="Toon op kaart"
+                    >
+                      <i className="bi bi-geo-alt" style={{ fontSize: '0.95rem' }} />
+                    </button>
+                  )}
                 </td>
-                <td style={{ backgroundColor: bg, color: hasColoredBg ? '#fff' : undefined }}>{hall.rating}</td>
               </tr>
             );
           })}

--- a/src/components/Halls.js
+++ b/src/components/Halls.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
 const VISITED_BG = '#2f7531';
-const CLOSED_BG = '#555';
+const CLOSED_BG  = '#555';
 
 function rowBg(hall) {
-  if (hall.closed) return CLOSED_BG;
+  if (hall.closed)  return CLOSED_BG;
   if (hall.visited) return VISITED_BG;
   return 'transparent';
 }
@@ -15,26 +15,27 @@ function Halls({ halls, sortBy }) {
       <table className="table table-striped border">
         <thead>
         <tr>
-          <th className={"bg-dark"}><button className={"btn btn-secondary"} onClick={() => sortBy('name')}>Naam</button></th>
-          <th className={"bg-dark"}><button className={"btn btn-secondary"} onClick={() => sortBy('city')}>Stad</button></th>
-          <th className={"bg-dark"}><button className={"btn btn-secondary"} onClick={() => sortBy('province')}>Provincie</button></th>
-          <th className={"bg-dark"}><button className={"btn btn-secondary"} onClick={() => sortBy('distance')}>Afstand</button></th>
-          <th className={"bg-dark"}><button className={"btn btn-secondary"} onClick={() => sortBy('rating')}>Rating</button></th>
+          <th className={"bg-dark text-white"}><button className={"btn btn-secondary"} onClick={() => sortBy('name')}>Naam</button></th>
+          <th className={"bg-dark text-white"}><button className={"btn btn-secondary"} onClick={() => sortBy('city')}>Stad</button></th>
+          <th className={"bg-dark text-white"}><button className={"btn btn-secondary"} onClick={() => sortBy('province')}>Provincie</button></th>
+          <th className={"bg-dark text-white"}><button className={"btn btn-secondary"} onClick={() => sortBy('distance')}>Afstand</button></th>
+          <th className={"bg-dark text-white"}><button className={"btn btn-secondary"} onClick={() => sortBy('rating')}>Rating</button></th>
         </tr>
         </thead>
         <tbody>
         {halls.map((hall, index) => {
           const bg = rowBg(hall);
+          const hasColoredBg = bg !== 'transparent';
           return (
             <tr key={index}>
-              <td className={"text-white"} style={{ backgroundColor: bg }}>
+              <td style={{ backgroundColor: bg, color: hasColoredBg ? 'white' : undefined }}>
                 {hall.name}
                 {hall.closed && <span className="badge bg-secondary ms-2" style={{ fontSize: '0.7em' }}>Gesloten</span>}
               </td>
-              <td className={"text-white"} style={{ backgroundColor: bg }}>{hall.city}</td>
-              <td className={"text-white"} style={{ backgroundColor: bg }}>{hall.province}</td>
-              <td className={"text-white"} style={{ backgroundColor: bg }}>{hall.distance ? `${hall.distance.toFixed(2)} km` : '-'}</td>
-              <td className={"text-white"} style={{ backgroundColor: bg }}>{hall.rating}</td>
+              <td style={{ backgroundColor: bg, color: hasColoredBg ? 'white' : undefined }}>{hall.city}</td>
+              <td style={{ backgroundColor: bg, color: hasColoredBg ? 'white' : undefined }}>{hall.province}</td>
+              <td style={{ backgroundColor: bg, color: hasColoredBg ? 'white' : undefined }}>{hall.distance ? `${hall.distance.toFixed(2)} km` : '-'}</td>
+              <td style={{ backgroundColor: bg, color: hasColoredBg ? 'white' : undefined }}>{hall.rating}</td>
             </tr>
           );
         })}

--- a/src/components/Halls.js
+++ b/src/components/Halls.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const VISITED_BG = '#2f7531';
-const CLOSED_BG  = '#555';
+const CLOSED_BG  = '#4b5563';
 
 function rowBg(hall) {
   if (hall.closed)  return CLOSED_BG;
@@ -12,33 +12,39 @@ function rowBg(hall) {
 function Halls({ halls, sortBy }) {
   return (
     <div className="table-responsive">
-      <table className="table table-striped border">
+      <table className="table table-striped table-hover">
         <thead>
-        <tr>
-          <th className={"bg-dark text-white"}><button className={"btn btn-secondary"} onClick={() => sortBy('name')}>Naam</button></th>
-          <th className={"bg-dark text-white"}><button className={"btn btn-secondary"} onClick={() => sortBy('city')}>Stad</button></th>
-          <th className={"bg-dark text-white"}><button className={"btn btn-secondary"} onClick={() => sortBy('province')}>Provincie</button></th>
-          <th className={"bg-dark text-white"}><button className={"btn btn-secondary"} onClick={() => sortBy('distance')}>Afstand</button></th>
-          <th className={"bg-dark text-white"}><button className={"btn btn-secondary"} onClick={() => sortBy('rating')}>Rating</button></th>
-        </tr>
+          <tr>
+            <th><button className="btn" onClick={() => sortBy('name')}>Naam</button></th>
+            <th><button className="btn" onClick={() => sortBy('city')}>Stad</button></th>
+            <th><button className="btn" onClick={() => sortBy('province')}>Provincie</button></th>
+            <th><button className="btn" onClick={() => sortBy('distance')}>Afstand</button></th>
+            <th><button className="btn" onClick={() => sortBy('rating')}>Rating</button></th>
+          </tr>
         </thead>
         <tbody>
-        {halls.map((hall, index) => {
-          const bg = rowBg(hall);
-          const hasColoredBg = bg !== 'transparent';
-          return (
-            <tr key={index}>
-              <td style={{ backgroundColor: bg, color: hasColoredBg ? 'white' : undefined }}>
-                {hall.name}
-                {hall.closed && <span className="badge bg-secondary ms-2" style={{ fontSize: '0.7em' }}>Gesloten</span>}
-              </td>
-              <td style={{ backgroundColor: bg, color: hasColoredBg ? 'white' : undefined }}>{hall.city}</td>
-              <td style={{ backgroundColor: bg, color: hasColoredBg ? 'white' : undefined }}>{hall.province}</td>
-              <td style={{ backgroundColor: bg, color: hasColoredBg ? 'white' : undefined }}>{hall.distance ? `${hall.distance.toFixed(2)} km` : '-'}</td>
-              <td style={{ backgroundColor: bg, color: hasColoredBg ? 'white' : undefined }}>{hall.rating}</td>
-            </tr>
-          );
-        })}
+          {halls.map((hall, index) => {
+            const bg = rowBg(hall);
+            const hasColoredBg = bg !== 'transparent';
+            return (
+              <tr key={index}>
+                <td style={{ backgroundColor: bg, color: hasColoredBg ? '#fff' : undefined }}>
+                  {hall.name}
+                  {hall.closed && (
+                    <span className="badge bg-secondary ms-2" style={{ fontSize: '0.68em', verticalAlign: 'middle' }}>
+                      Gesloten
+                    </span>
+                  )}
+                </td>
+                <td style={{ backgroundColor: bg, color: hasColoredBg ? '#fff' : undefined }}>{hall.city}</td>
+                <td style={{ backgroundColor: bg, color: hasColoredBg ? '#fff' : undefined }}>{hall.province}</td>
+                <td style={{ backgroundColor: bg, color: hasColoredBg ? '#fff' : undefined }}>
+                  {hall.distance ? `${hall.distance.toFixed(1)} km` : '—'}
+                </td>
+                <td style={{ backgroundColor: bg, color: hasColoredBg ? '#fff' : undefined }}>{hall.rating}</td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/src/components/Halls.js
+++ b/src/components/Halls.js
@@ -1,8 +1,15 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-function Halls( { halls, sortBy } ) {
-  const [visitedColour] = useState('#2f7531');
+const VISITED_BG = '#2f7531';
+const CLOSED_BG = '#555';
 
+function rowBg(hall) {
+  if (hall.closed) return CLOSED_BG;
+  if (hall.visited) return VISITED_BG;
+  return 'transparent';
+}
+
+function Halls({ halls, sortBy }) {
   return (
     <div className="table-responsive">
       <table className="table table-striped border">
@@ -16,15 +23,21 @@ function Halls( { halls, sortBy } ) {
         </tr>
         </thead>
         <tbody>
-        {halls.map((hall, index) => (
-          <tr key={index}>
-            <td className={"text-white"} style={{ backgroundColor: hall.visited ? visitedColour : 'transparent' }}>{hall.name}</td>
-            <td className={"text-white"} style={{ backgroundColor: hall.visited ? visitedColour : 'transparent' }}>{hall.city}</td>
-            <td className={"text-white"} style={{ backgroundColor: hall.visited ? visitedColour : 'transparent' }}>{hall.province}</td>
-            <td className={"text-white"} style={{ backgroundColor: hall.visited ? visitedColour : 'transparent' }}>{hall.distance ? `${hall.distance.toFixed(2)} km` : '-'}</td>
-            <td className={"text-white"} style={{ backgroundColor: hall.visited ? visitedColour : 'transparent' }}>{hall.rating}</td>
-          </tr>
-        ))}
+        {halls.map((hall, index) => {
+          const bg = rowBg(hall);
+          return (
+            <tr key={index}>
+              <td className={"text-white"} style={{ backgroundColor: bg }}>
+                {hall.name}
+                {hall.closed && <span className="badge bg-secondary ms-2" style={{ fontSize: '0.7em' }}>Gesloten</span>}
+              </td>
+              <td className={"text-white"} style={{ backgroundColor: bg }}>{hall.city}</td>
+              <td className={"text-white"} style={{ backgroundColor: bg }}>{hall.province}</td>
+              <td className={"text-white"} style={{ backgroundColor: bg }}>{hall.distance ? `${hall.distance.toFixed(2)} km` : '-'}</td>
+              <td className={"text-white"} style={{ backgroundColor: bg }}>{hall.rating}</td>
+            </tr>
+          );
+        })}
         </tbody>
       </table>
     </div>

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -22,15 +22,20 @@ function markerColor(hall) {
 
 function Pin({ color }) {
   return (
-    <div style={{
-      width: 14,
-      height: 14,
-      borderRadius: '50%',
-      backgroundColor: color,
-      border: '2px solid #fff',
-      boxShadow: '0 2px 4px rgba(0,0,0,0.45)',
-      cursor: 'pointer',
-    }} />
+    <svg width="22" height="32" viewBox="0 0 22 32" style={{ cursor: 'pointer', filter: 'drop-shadow(0 2px 3px rgba(0,0,0,0.4))' }}>
+      <path d="M11 0C4.925 0 0 4.925 0 11c0 7.667 11 21 11 21s11-13.333 11-21C22 4.925 17.075 0 11 0z" fill={color} />
+      <circle cx="11" cy="11" r="4.5" fill="white" fillOpacity="0.75" />
+    </svg>
+  );
+}
+
+function UserPin() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" style={{ filter: 'drop-shadow(0 2px 3px rgba(0,0,0,0.4))' }}>
+      <circle cx="9" cy="9" r="9" fill={COLORS.user} />
+      <circle cx="9" cy="9" r="5" fill="white" />
+      <circle cx="9" cy="9" r="3" fill={COLORS.user} />
+    </svg>
   );
 }
 
@@ -81,7 +86,7 @@ function MapInner({ data, coords }) {
 
       {coords?.latitude && coords?.longitude && (
         <AdvancedMarker position={{ lat: coords.latitude, lng: coords.longitude }}>
-          <Pin color={COLORS.user} />
+          <UserPin />
         </AdvancedMarker>
       )}
 
@@ -90,12 +95,28 @@ function MapInner({ data, coords }) {
           position={{ lat: selected.latitude, lng: selected.longitude }}
           onCloseClick={() => setSelected(null)}
         >
-          <div style={{ color: '#222', minWidth: 120 }}>
+          <div style={{ color: '#222', minWidth: 140 }}>
             <strong>{selected.name}</strong><br />
             <span style={{ fontSize: '0.85em', color: '#555' }}>{selected.city}</span>
             {selected.closed && (
               <><br /><span style={{ fontSize: '0.8em', color: '#888' }}>Gesloten</span></>
             )}
+            <br />
+            <a
+              href={`https://www.google.com/maps/dir/?api=1&destination=${selected.latitude},${selected.longitude}&destination_place_id=${selected.name}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                display: 'inline-block',
+                marginTop: 6,
+                fontSize: '0.82em',
+                color: '#1a73e8',
+                textDecoration: 'none',
+                fontWeight: 500,
+              }}
+            >
+              ↗ Route
+            </a>
           </div>
         </InfoWindow>
       )}

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -7,6 +7,18 @@ import {
   useMap,
 } from '@vis.gl/react-google-maps';
 
+// Simplified Netherlands boundary [lng, lat], counterclockwise.
+// Reversed below to make a clockwise hole in the world overlay polygon.
+const NL_POLYGON = [
+  [3.36, 51.37], [4.22, 51.37], [4.84, 51.42], [5.50, 51.28],
+  [5.67, 50.75], [5.87, 50.75], [5.98, 51.48], [6.00, 51.76],
+  [6.17, 51.90], [6.75, 52.10], [6.97, 52.47], [7.05, 52.65],
+  [7.09, 53.30], [6.45, 53.46], [5.84, 53.42], [5.10, 53.26],
+  [4.80, 53.05], [4.55, 52.95], [4.60, 52.47], [4.42, 52.28],
+  [4.19, 52.19], [4.05, 52.00], [4.14, 51.75], [3.84, 51.58],
+  [3.37, 51.52], [3.36, 51.37],
+];
+
 const COLORS = {
   visited: '#2f7531',
   closed:  '#666666',
@@ -37,6 +49,36 @@ function UserPin() {
       <circle cx="9" cy="9" r="3" fill={COLORS.user} />
     </svg>
   );
+}
+
+function NetherlandsOverlay() {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!map) return;
+
+    // World bounding box (counterclockwise = exterior) with NL as a clockwise hole.
+    // The gray fill covers everything outside the hole (i.e. outside the Netherlands).
+    const worldRing = [[-180, -85], [180, -85], [180, 85], [-180, 85], [-180, -85]];
+    const nlHole = [...NL_POLYGON].reverse(); // clockwise → hole
+
+    const features = map.data.addGeoJson({
+      type: 'Feature',
+      geometry: { type: 'Polygon', coordinates: [worldRing, nlHole] },
+      properties: {},
+    });
+
+    map.data.setStyle({
+      fillColor: '#000',
+      fillOpacity: 0.28,
+      strokeWeight: 0,
+      clickable: false,
+    });
+
+    return () => features.forEach((f) => map.data.remove(f));
+  }, [map]);
+
+  return null;
 }
 
 function PanToUser({ coords }) {
@@ -73,6 +115,7 @@ function MapInner({ data, coords }) {
       mapId={process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID}
     >
       <PanToUser coords={coords} />
+      <NetherlandsOverlay />
 
       {halls.map((hall, i) => (
         <AdvancedMarker

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -123,7 +123,7 @@ function PlacePhoto({ hall }) {
 
 function MapInner({ data, coords, isDark }) {
   const [selected, setSelected] = useState(null);
-  const halls = data.filter((h) => h.latitude && h.longitude);
+  const halls = data.filter((h) => h.latitude && h.longitude && !h.closed);
 
   const defaultCenter = (() => {
     if (coords?.latitude) return { lat: coords.latitude, lng: coords.longitude };

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -170,7 +170,7 @@ function MapInner({ data, coords, isDark }) {
           minWidth={220}
         >
           <div style={{ color: '#222', width: 210 }}>
-            <PlacePhoto hall={selected} />
+            <PlacePhoto key={selected.name} hall={selected} />
             <div style={{ marginTop: photoCache[selected.name] === null ? 0 : 8 }}>
               <strong style={{ fontSize: '0.95em' }}>{selected.name}</strong><br />
               <span style={{ fontSize: '0.82em', color: '#555' }}>{selected.city}</span>

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -143,6 +143,7 @@ function MapInner({ data, coords, isDark }) {
       minZoom={3}
       gestureHandling="cooperative"
       mapId={process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID}
+      colorScheme={isDark ? 'DARK' : 'LIGHT'}
     >
       <MapColorScheme isDark={isDark} />
       <PanToUser coords={coords} />

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -52,6 +52,16 @@ function MapColorScheme({ isDark }) {
   return null;
 }
 
+function PanToFocused({ focusRequest }) {
+  const map = useMap();
+  useEffect(() => {
+    if (!map || !focusRequest?.hall) return;
+    map.panTo({ lat: focusRequest.hall.latitude, lng: focusRequest.hall.longitude });
+    map.setZoom(14);
+  }, [map, focusRequest]);
+  return null;
+}
+
 function PanToUser({ coords }) {
   const map = useMap();
   useEffect(() => {
@@ -121,8 +131,12 @@ function PlacePhoto({ hall }) {
   );
 }
 
-function MapInner({ data, coords, isDark }) {
+function MapInner({ data, coords, isDark, focusRequest }) {
   const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    if (focusRequest?.hall) setSelected(focusRequest.hall);
+  }, [focusRequest]);
   const halls = data.filter((h) => h.latitude && h.longitude && !h.closed);
 
   const defaultCenter = (() => {
@@ -147,6 +161,7 @@ function MapInner({ data, coords, isDark }) {
     >
       <MapColorScheme isDark={isDark} />
       <PanToUser coords={coords} />
+      <PanToFocused focusRequest={focusRequest} />
 
       {halls.map((hall, i) => (
         <AdvancedMarker
@@ -201,14 +216,14 @@ function MapInner({ data, coords, isDark }) {
   );
 }
 
-function Map({ data, coords, isDark }) {
+function Map({ data, coords, isDark, focusRequest }) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => { setMounted(true); }, []);
   if (!mounted) return <div style={{ height: '50vh', width: '100%' }} />;
 
   return (
     <APIProvider apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? ''}>
-      <MapInner data={data} coords={coords} isDark={isDark} />
+      <MapInner data={data} coords={coords} isDark={isDark} focusRequest={focusRequest} />
     </APIProvider>
   );
 }

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -5,6 +5,7 @@ import {
   AdvancedMarker,
   InfoWindow,
   useMap,
+  useMapsLibrary,
 } from '@vis.gl/react-google-maps';
 
 const COLORS = {
@@ -13,6 +14,9 @@ const COLORS = {
   open:    '#1a73e8',
   user:    '#ea4335',
 };
+
+// Module-level cache — survives Map remounts when the toggle is pressed
+const photoCache = {};
 
 function markerColor(hall) {
   if (hall.closed)  return COLORS.closed;
@@ -56,6 +60,65 @@ function PanToUser({ coords }) {
     }
   }, [map, coords]);
   return null;
+}
+
+// Fetches a Google Places photo for the hall, with module-level caching.
+// Requires "Places API (New)" enabled on the Maps JS API key in Google Cloud Console.
+function PlacePhoto({ hall }) {
+  const placesLib = useMapsLibrary('places');
+  const [photoUrl, setPhotoUrl] = useState(() =>
+    hall.name in photoCache ? photoCache[hall.name] : undefined
+  );
+
+  useEffect(() => {
+    if (hall.name in photoCache) {
+      setPhotoUrl(photoCache[hall.name]);
+      return;
+    }
+    if (!placesLib?.Place) return;
+
+    placesLib.Place.searchByText({
+      textQuery: `${hall.name} ${hall.city}`,
+      fields: ['photos'],
+      maxResultCount: 1,
+      region: 'nl',
+    }).then(({ places }) => {
+      const url = places?.[0]?.photos?.[0]?.getURI({ maxWidth: 300 }) ?? null;
+      photoCache[hall.name] = url;
+      setPhotoUrl(url);
+    }).catch(() => {
+      photoCache[hall.name] = null;
+      setPhotoUrl(null);
+    });
+  }, [placesLib, hall.name, hall.city]);
+
+  if (photoUrl === undefined) {
+    return (
+      <div style={{
+        height: 110,
+        background: 'var(--bs-secondary-bg, #e9ecef)',
+        borderRadius: 6,
+        marginTop: 8,
+        animation: 'pulse 1.5s ease-in-out infinite',
+      }} />
+    );
+  }
+  if (!photoUrl) return null;
+
+  return (
+    <img
+      src={photoUrl}
+      alt={hall.name}
+      style={{
+        width: '100%',
+        maxHeight: 150,
+        objectFit: 'cover',
+        borderRadius: 6,
+        marginTop: 8,
+        display: 'block',
+      }}
+    />
+  );
 }
 
 function MapInner({ data, coords, isDark }) {
@@ -104,25 +167,28 @@ function MapInner({ data, coords, isDark }) {
         <InfoWindow
           position={{ lat: selected.latitude, lng: selected.longitude }}
           onCloseClick={() => setSelected(null)}
+          minWidth={220}
         >
-          <div style={{ color: '#222', minWidth: 140 }}>
-            <strong>{selected.name}</strong><br />
-            <span style={{ fontSize: '0.85em', color: '#555' }}>{selected.city}</span>
-            {selected.closed && (
-              <><br /><span style={{ fontSize: '0.8em', color: '#888' }}>Gesloten</span></>
-            )}
-            <br />
+          <div style={{ color: '#222', width: 210 }}>
+            <PlacePhoto hall={selected} />
+            <div style={{ marginTop: photoCache[selected.name] === null ? 0 : 8 }}>
+              <strong style={{ fontSize: '0.95em' }}>{selected.name}</strong><br />
+              <span style={{ fontSize: '0.82em', color: '#555' }}>{selected.city}</span>
+              {selected.closed && (
+                <><br /><span style={{ fontSize: '0.78em', color: '#888' }}>Gesloten</span></>
+              )}
+            </div>
             <a
-              href={`https://www.google.com/maps/dir/?api=1&destination=${selected.latitude},${selected.longitude}`}
+              href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(`${selected.name}, ${selected.city}, Nederland`)}`}
               target="_blank"
               rel="noopener noreferrer"
               style={{
                 display: 'inline-block',
-                marginTop: 6,
+                marginTop: 8,
                 fontSize: '0.82em',
                 color: '#1a73e8',
                 textDecoration: 'none',
-                fontWeight: 500,
+                fontWeight: 600,
               }}
             >
               ↗ Route

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -7,18 +7,6 @@ import {
   useMap,
 } from '@vis.gl/react-google-maps';
 
-// Simplified Netherlands boundary [lng, lat], counterclockwise.
-// Reversed below to make a clockwise hole in the world overlay polygon.
-const NL_POLYGON = [
-  [3.36, 51.37], [4.22, 51.37], [4.84, 51.42], [5.50, 51.28],
-  [5.67, 50.75], [5.87, 50.75], [5.98, 51.48], [6.00, 51.76],
-  [6.17, 51.90], [6.75, 52.10], [6.97, 52.47], [7.05, 52.65],
-  [7.09, 53.30], [6.45, 53.46], [5.84, 53.42], [5.10, 53.26],
-  [4.80, 53.05], [4.55, 52.95], [4.60, 52.47], [4.42, 52.28],
-  [4.19, 52.19], [4.05, 52.00], [4.14, 51.75], [3.84, 51.58],
-  [3.37, 51.52], [3.36, 51.37],
-];
-
 const COLORS = {
   visited: '#2f7531',
   closed:  '#666666',
@@ -51,33 +39,12 @@ function UserPin() {
   );
 }
 
-function NetherlandsOverlay() {
+function MapColorScheme({ isDark }) {
   const map = useMap();
-
   useEffect(() => {
     if (!map) return;
-
-    // World bounding box (counterclockwise = exterior) with NL as a clockwise hole.
-    // The gray fill covers everything outside the hole (i.e. outside the Netherlands).
-    const worldRing = [[-180, -85], [180, -85], [180, 85], [-180, 85], [-180, -85]];
-    const nlHole = [...NL_POLYGON].reverse(); // clockwise → hole
-
-    const features = map.data.addGeoJson({
-      type: 'Feature',
-      geometry: { type: 'Polygon', coordinates: [worldRing, nlHole] },
-      properties: {},
-    });
-
-    map.data.setStyle({
-      fillColor: '#000',
-      fillOpacity: 0.28,
-      strokeWeight: 0,
-      clickable: false,
-    });
-
-    return () => features.forEach((f) => map.data.remove(f));
-  }, [map]);
-
+    map.setOptions({ colorScheme: isDark ? 'DARK' : 'LIGHT' });
+  }, [map, isDark]);
   return null;
 }
 
@@ -91,7 +58,7 @@ function PanToUser({ coords }) {
   return null;
 }
 
-function MapInner({ data, coords }) {
+function MapInner({ data, coords, isDark }) {
   const [selected, setSelected] = useState(null);
   const halls = data.filter((h) => h.latitude && h.longitude);
 
@@ -114,8 +81,8 @@ function MapInner({ data, coords }) {
       gestureHandling="cooperative"
       mapId={process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID}
     >
+      <MapColorScheme isDark={isDark} />
       <PanToUser coords={coords} />
-      <NetherlandsOverlay />
 
       {halls.map((hall, i) => (
         <AdvancedMarker
@@ -146,7 +113,7 @@ function MapInner({ data, coords }) {
             )}
             <br />
             <a
-              href={`https://www.google.com/maps/dir/?api=1&destination=${selected.latitude},${selected.longitude}&destination_place_id=${selected.name}`}
+              href={`https://www.google.com/maps/dir/?api=1&destination=${selected.latitude},${selected.longitude}`}
               target="_blank"
               rel="noopener noreferrer"
               style={{
@@ -167,14 +134,14 @@ function MapInner({ data, coords }) {
   );
 }
 
-function Map({ data, coords }) {
+function Map({ data, coords, isDark }) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => { setMounted(true); }, []);
   if (!mounted) return <div style={{ height: '50vh', width: '100%' }} />;
 
   return (
     <APIProvider apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? ''}>
-      <MapInner data={data} coords={coords} />
+      <MapInner data={data} coords={coords} isDark={isDark} />
     </APIProvider>
   );
 }

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,134 +1,117 @@
-import {useEffect, useState, useMemo, useRef} from 'react';
-import {MapContainer, Marker, Popup, TileLayer, useMap} from "react-leaflet";
-import L from 'leaflet';
+import { useState, useEffect } from 'react';
+import {
+  APIProvider,
+  Map as GoogleMap,
+  AdvancedMarker,
+  InfoWindow,
+  useMap,
+} from '@vis.gl/react-google-maps';
 
-// Create icons outside component to avoid recreation
-const icons = {
-  blueIcon: new L.Icon({
-    iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-blue.png',
-    shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-    iconSize: [25, 41],
-    iconAnchor: [12, 41],
-    popupAnchor: [1, -34],
-    shadowSize: [41, 41]
-  }),
-  greenIcon: new L.Icon({
-    iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-green.png',
-    shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-    iconSize: [25, 41],
-    iconAnchor: [12, 41],
-    popupAnchor: [1, -34],
-    shadowSize: [41, 41]
-  }),
-  redIcon: new L.Icon({
-    iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-red.png',
-    shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
-    iconSize: [25, 41],
-    iconAnchor: [12, 41],
-    popupAnchor: [1, -34],
-    shadowSize: [41, 41]
-  })
+const COLORS = {
+  visited: '#2f7531',
+  closed:  '#666666',
+  open:    '#1a73e8',
+  user:    '#ea4335',
 };
 
-const ComponentResize = () => {
-  const map = useMap();
-  useEffect(() => {
-    setTimeout(() => {
-      map.invalidateSize();
-    }, 0);
-  }, [map]);
-  return null;
-};
+function markerColor(hall) {
+  if (hall.closed)  return COLORS.closed;
+  if (hall.visited) return COLORS.visited;
+  return COLORS.open;
+}
 
-const UpdateCenter = ({coords}) => {
-  const map = useMap();
-
-  useEffect(() => {
-    if (coords && coords.latitude && coords.longitude) {
-      map.panTo(new L.LatLng(coords.latitude, coords.longitude), map.getZoom(), {animate: true, duration: 0.5});
-    }
-  }, [coords, map]);
-
-  return null;
-};
-
-function Map({data, coords}) {
-  const [mounted, setMounted] = useState(false);
-  const mapRef = useRef(null);
-
-  useEffect(() => {
-    // Set mounted to true immediately on client side
-    setMounted(true);
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (mapRef.current) {
-        const container = mapRef.current.getContainer?.() || mapRef.current._container;
-        mapRef.current.remove();
-        // Defensive cleanup for StrictMode double-invoke in dev.
-        if (container && container._leaflet_id) {
-          container._leaflet_id = null;
-        }
-        mapRef.current = null;
-      }
-    };
-  }, []);
-
-  const calculateCenter = (data) => {
-    const latitudes = data.map(marker => marker.latitude);
-    const longitudes = data.map(marker => marker.longitude);
-    const center = {
-      latitude: (Math.min(...latitudes) + Math.max(...latitudes)) / 2,
-      longitude: (Math.min(...longitudes) + Math.max(...longitudes)) / 2
-    };
-    return [center.latitude, center.longitude];
-  };
-
-  const visibleHalls = useMemo(() =>
-    data.filter(marker => marker.latitude && marker.longitude),
-    [data]
+function Pin({ color }) {
+  return (
+    <div style={{
+      width: 14,
+      height: 14,
+      borderRadius: '50%',
+      backgroundColor: color,
+      border: '2px solid #fff',
+      boxShadow: '0 2px 4px rgba(0,0,0,0.45)',
+      cursor: 'pointer',
+    }} />
   );
+}
 
-  // Don't render until mounted (client-side only)
-  if (!mounted) {
-    return <div style={{height: "50vh", width: "100%"}} />;
-  }
+function PanToUser({ coords }) {
+  const map = useMap();
+  useEffect(() => {
+    if (map && coords?.latitude && coords?.longitude) {
+      map.panTo({ lat: coords.latitude, lng: coords.longitude });
+    }
+  }, [map, coords]);
+  return null;
+}
+
+function MapInner({ data, coords }) {
+  const [selected, setSelected] = useState(null);
+  const halls = data.filter((h) => h.latitude && h.longitude);
+
+  const defaultCenter = (() => {
+    if (coords?.latitude) return { lat: coords.latitude, lng: coords.longitude };
+    const lats = halls.map((h) => h.latitude);
+    const lngs = halls.map((h) => h.longitude);
+    return {
+      lat: (Math.min(...lats) + Math.max(...lats)) / 2,
+      lng: (Math.min(...lngs) + Math.max(...lngs)) / 2,
+    };
+  })();
 
   return (
-    <MapContainer
-      style={{height: "50vh", width: "100%"}}
-      center={coords && coords.latitude && coords.longitude ? [coords.latitude, coords.longitude] : calculateCenter(data)}
-      zoom={coords && coords.latitude && coords.longitude ? 11 : 8}
+    <GoogleMap
+      style={{ height: '50vh', width: '100%' }}
+      defaultCenter={defaultCenter}
+      defaultZoom={coords?.latitude ? 11 : 8}
       minZoom={3}
-      scrollWheelZoom={true}
-      whenCreated={(map) => {
-        mapRef.current = map;
-      }}
+      gestureHandling="cooperative"
+      mapId={process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID}
     >
-      <ComponentResize/>
-      <TileLayer
-        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-      />
-      <UpdateCenter coords={coords}/>
-      {visibleHalls.map((marker, index) => (
-        <Marker
-          key={index}
-          position={[marker.latitude, marker.longitude]}
-          icon={marker.visited ? icons.greenIcon : icons.blueIcon}>
-          <Popup>{marker.name}<br/>{marker.description}</Popup>
-        </Marker>
+      <PanToUser coords={coords} />
+
+      {halls.map((hall, i) => (
+        <AdvancedMarker
+          key={i}
+          position={{ lat: hall.latitude, lng: hall.longitude }}
+          onClick={() => setSelected(hall)}
+        >
+          <Pin color={markerColor(hall)} />
+        </AdvancedMarker>
       ))}
-      {coords && coords.latitude && coords.longitude && (
-        <Marker
-          key="current"
-          position={[coords.latitude, coords.longitude]}
-          icon={icons.redIcon}>
-          <Popup>Huidige locatie</Popup>
-        </Marker>
+
+      {coords?.latitude && coords?.longitude && (
+        <AdvancedMarker position={{ lat: coords.latitude, lng: coords.longitude }}>
+          <Pin color={COLORS.user} />
+        </AdvancedMarker>
       )}
-    </MapContainer>
+
+      {selected && (
+        <InfoWindow
+          position={{ lat: selected.latitude, lng: selected.longitude }}
+          onCloseClick={() => setSelected(null)}
+        >
+          <div style={{ color: '#222', minWidth: 120 }}>
+            <strong>{selected.name}</strong><br />
+            <span style={{ fontSize: '0.85em', color: '#555' }}>{selected.city}</span>
+            {selected.closed && (
+              <><br /><span style={{ fontSize: '0.8em', color: '#888' }}>Gesloten</span></>
+            )}
+          </div>
+        </InfoWindow>
+      )}
+    </GoogleMap>
+  );
+}
+
+function Map({ data, coords }) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+  if (!mounted) return <div style={{ height: '50vh', width: '100%' }} />;
+
+  return (
+    <APIProvider apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? ''}>
+      <MapInner data={data} coords={coords} />
+    </APIProvider>
   );
 }
 

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -180,7 +180,7 @@ function MapInner({ data, coords, isDark }) {
               )}
             </div>
             <a
-              href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(`${selected.name}, ${selected.city}, Nederland`)}`}
+              href={`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(`${selected.name}, ${selected.city}, Nederland`)}&travelmode=transit`}
               target="_blank"
               rel="noopener noreferrer"
               style={{

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import "bootstrap-icons/font/bootstrap-icons.css";
 
-function Search({ showVisited, visitedFiltered, showMap, visitedCount, hallCount, onSearchChange, showClosed, toggleShowClosed, closedCount, isDark, toggleTheme }) {
+function Search({ showVisited, visitedFiltered, showOnlyClosed, closedFiltered, showMap, mapVisible, visitedCount, hallCount, onSearchChange, closedCount }) {
   return (
     <div className="filter-bar">
       <span className="btn btn-info" style={{ flexShrink: 0 }}>{hallCount}</span>
@@ -21,24 +21,21 @@ function Search({ showVisited, visitedFiltered, showMap, visitedCount, hallCount
       </button>
       {closedCount > 0 && (
         <button
-          className={`btn ${showClosed ? 'btn-secondary' : 'btn-outline-secondary'}`}
-          onClick={toggleShowClosed}
-          title={showClosed ? 'Gesloten verbergen' : 'Gesloten tonen'}
+          className={`btn ${closedFiltered ? 'btn-secondary' : 'btn-outline-secondary'}`}
+          onClick={showOnlyClosed}
+          title={closedFiltered ? 'Toon alle hallen' : 'Toon alleen gesloten'}
           style={{ flexShrink: 0 }}
         >
           {closedCount} <span className="d-none d-sm-inline">gesloten</span>
         </button>
       )}
-      <button className="btn btn-warning" onClick={showMap} title="Kaart" style={{ flexShrink: 0 }}>
-        <i className="bi bi-geo-alt-fill" />
-      </button>
       <button
-        className="btn btn-outline-secondary"
-        onClick={toggleTheme}
-        title={isDark ? 'Lichtmodus' : 'Donkermodus'}
+        className={`btn ${mapVisible ? 'btn-secondary' : 'btn-outline-secondary'}`}
+        onClick={showMap}
+        title="Kaart"
         style={{ flexShrink: 0 }}
       >
-        <i className={isDark ? 'bi bi-sun-fill' : 'bi bi-moon-fill'} />
+        <i className="bi bi-map" />
       </button>
     </div>
   );

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import "bootstrap-icons/font/bootstrap-icons.css";
 
-function Search({ showVisited, showMap, visitedCount, hallCount, onSearchChange, showClosed, toggleShowClosed, closedCount }) {
+function Search({ showVisited, showMap, visitedCount, hallCount, onSearchChange, showClosed, toggleShowClosed, closedCount, isDark, toggleTheme }) {
   const handleSearchInput = (event) => {
     onSearchChange(event.target.value);
   };
@@ -35,6 +35,14 @@ function Search({ showVisited, showMap, visitedCount, hallCount, onSearchChange,
         )}
         <button id="mapToggle" className="btn btn-warning" onClick={showMap}>
           <i className="bi bi-geo-alt-fill"></i>
+        </button>
+        <button
+          id="themeToggle"
+          className="btn btn-outline-secondary"
+          onClick={toggleTheme}
+          title={isDark ? 'Schakel naar lichtmodus' : 'Schakel naar donkermodus'}
+        >
+          <i className={isDark ? 'bi bi-sun-fill' : 'bi bi-moon-fill'} />
         </button>
       </div>
     </div>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import "bootstrap-icons/font/bootstrap-icons.css";
 
-function Search({ showVisited, showMap, visitedCount, hallCount, onSearchChange, showClosed, toggleShowClosed, closedCount, isDark, toggleTheme }) {
+function Search({ showVisited, visitedFiltered, showMap, visitedCount, hallCount, onSearchChange, showClosed, toggleShowClosed, closedCount, isDark, toggleTheme }) {
   return (
     <div className="filter-bar">
       <span className="btn btn-info" style={{ flexShrink: 0 }}>{hallCount}</span>
@@ -12,12 +12,16 @@ function Search({ showVisited, showMap, visitedCount, hallCount, onSearchChange,
         aria-label="search"
         onInput={(e) => onSearchChange(e.target.value)}
       />
-      <button className="btn btn-success" onClick={showVisited} style={{ flexShrink: 0 }}>
+      <button
+        className={`btn ${visitedFiltered ? 'btn-success' : 'btn-outline-success'}`}
+        onClick={showVisited}
+        style={{ flexShrink: 0 }}
+      >
         {visitedCount} <span className="d-none d-sm-inline">bezocht</span>
       </button>
       {closedCount > 0 && (
         <button
-          className={`btn btn-outline-secondary${showClosed ? ' active' : ''}`}
+          className={`btn ${showClosed ? 'btn-secondary' : 'btn-outline-secondary'}`}
           onClick={toggleShowClosed}
           title={showClosed ? 'Gesloten verbergen' : 'Gesloten tonen'}
           style={{ flexShrink: 0 }}

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -2,49 +2,40 @@ import React from 'react';
 import "bootstrap-icons/font/bootstrap-icons.css";
 
 function Search({ showVisited, showMap, visitedCount, hallCount, onSearchChange, showClosed, toggleShowClosed, closedCount, isDark, toggleTheme }) {
-  const handleSearchInput = (event) => {
-    onSearchChange(event.target.value);
-  };
-  const placeholderText = `Zoek door ${hallCount} hallen...`;
-
   return (
-    <div className="col-md">
-      <div className="input-group mb-3">
-        <button id="displayedHallsCounter" className="btn btn-info disabled d-md-inline-block">{hallCount}</button>
-        <input
-          type="text"
-          id="searchInput"
-          className="form-control"
-          placeholder={placeholderText}
-          aria-label="search"
-          aria-describedby="basic-addon1"
-          onInput={handleSearchInput}
-        />
-        <button id="visitedCounter" className="btn btn-success d-md-inline-block" onClick={showVisited}>
-          {visitedCount} <span className="d-none d-sm-inline">bezocht</span>
-        </button>
-        {closedCount > 0 && (
-          <button
-            id="closedToggle"
-            className={`btn ${showClosed ? 'btn-secondary active' : 'btn-outline-secondary'}`}
-            onClick={toggleShowClosed}
-            title={showClosed ? 'Gesloten verbergen' : 'Gesloten tonen'}
-          >
-            {closedCount} <span className="d-none d-sm-inline">gesloten</span>
-          </button>
-        )}
-        <button id="mapToggle" className="btn btn-warning" onClick={showMap}>
-          <i className="bi bi-geo-alt-fill"></i>
-        </button>
+    <div className="filter-bar">
+      <span className="btn btn-info" style={{ flexShrink: 0 }}>{hallCount}</span>
+      <input
+        type="text"
+        className="form-control"
+        placeholder="Zoeken..."
+        aria-label="search"
+        onInput={(e) => onSearchChange(e.target.value)}
+      />
+      <button className="btn btn-success" onClick={showVisited} style={{ flexShrink: 0 }}>
+        {visitedCount} <span className="d-none d-sm-inline">bezocht</span>
+      </button>
+      {closedCount > 0 && (
         <button
-          id="themeToggle"
-          className="btn btn-outline-secondary"
-          onClick={toggleTheme}
-          title={isDark ? 'Schakel naar lichtmodus' : 'Schakel naar donkermodus'}
+          className={`btn btn-outline-secondary${showClosed ? ' active' : ''}`}
+          onClick={toggleShowClosed}
+          title={showClosed ? 'Gesloten verbergen' : 'Gesloten tonen'}
+          style={{ flexShrink: 0 }}
         >
-          <i className={isDark ? 'bi bi-sun-fill' : 'bi bi-moon-fill'} />
+          {closedCount} <span className="d-none d-sm-inline">gesloten</span>
         </button>
-      </div>
+      )}
+      <button className="btn btn-warning" onClick={showMap} title="Kaart" style={{ flexShrink: 0 }}>
+        <i className="bi bi-geo-alt-fill" />
+      </button>
+      <button
+        className="btn btn-outline-secondary"
+        onClick={toggleTheme}
+        title={isDark ? 'Lichtmodus' : 'Donkermodus'}
+        style={{ flexShrink: 0 }}
+      >
+        <i className={isDark ? 'bi bi-sun-fill' : 'bi bi-moon-fill'} />
+      </button>
     </div>
   );
 }

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import "bootstrap-icons/font/bootstrap-icons.css";
 
-function Search({ showVisited, showMap, visitedCount, hallCount, onSearchChange }) {
+function Search({ showVisited, showMap, visitedCount, hallCount, onSearchChange, showClosed, toggleShowClosed, closedCount }) {
   const handleSearchInput = (event) => {
     onSearchChange(event.target.value);
   };
@@ -23,6 +23,16 @@ function Search({ showVisited, showMap, visitedCount, hallCount, onSearchChange 
         <button id="visitedCounter" className="btn btn-success d-md-inline-block" onClick={showVisited}>
           {visitedCount} <span className="d-none d-sm-inline">bezocht</span>
         </button>
+        {closedCount > 0 && (
+          <button
+            id="closedToggle"
+            className={`btn ${showClosed ? 'btn-secondary active' : 'btn-outline-secondary'}`}
+            onClick={toggleShowClosed}
+            title={showClosed ? 'Gesloten verbergen' : 'Gesloten tonen'}
+          >
+            {closedCount} <span className="d-none d-sm-inline">gesloten</span>
+          </button>
+        )}
         <button id="mapToggle" className="btn btn-warning" onClick={showMap}>
           <i className="bi bi-geo-alt-fill"></i>
         </button>

--- a/src/halls.json
+++ b/src/halls.json
@@ -11,14 +11,14 @@
     "geocodeSource": "manual"
   },
   {
-    "name": "Be Boulder",
+    "name": "Boulderhal Luchthaven",
     "city": "Amsterdam",
     "province": "Noord-Holland",
     "latitude": 52.3395626,
     "longitude": 4.8418298,
     "visited": true,
     "rating": 2,
-    "closed": true,
+    "closed": false,
     "geocodeSource": "manual"
   },
   {

--- a/src/halls.json
+++ b/src/halls.json
@@ -11,26 +11,15 @@
     "geocodeSource": "manual"
   },
   {
-    "name": "Be Boulder",
+    "name": "Be Boulder (Luchthaven 2026)",
     "city": "Amsterdam",
     "province": "Noord-Holland",
     "latitude": 52.3395626,
     "longitude": 4.8418298,
-    "visited": true,
-    "rating": 2,
-    "closed": true,
-    "geocodeSource": "manual"
-  },
-  {
-    "name": "Boulderhal Luchthaven",
-    "city": "Amsterdam",
-    "province": "Noord-Holland",
-    "latitude": 52.3105,
-    "longitude": 4.7639,
     "visited": false,
     "rating": "N/A",
     "closed": false,
-    "geocodeSource": "city-fallback"
+    "geocodeSource": "manual"
   },
   {
     "name": "Beest Boulders Adam",

--- a/src/halls.json
+++ b/src/halls.json
@@ -11,15 +11,26 @@
     "geocodeSource": "manual"
   },
   {
-    "name": "Boulderhal Luchthaven",
+    "name": "Be Boulder",
     "city": "Amsterdam",
     "province": "Noord-Holland",
     "latitude": 52.3395626,
     "longitude": 4.8418298,
     "visited": true,
     "rating": 2,
-    "closed": false,
+    "closed": true,
     "geocodeSource": "manual"
+  },
+  {
+    "name": "Boulderhal Luchthaven",
+    "city": "Amsterdam",
+    "province": "Noord-Holland",
+    "latitude": 52.3105,
+    "longitude": 4.7639,
+    "visited": false,
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "city-fallback"
   },
   {
     "name": "Beest Boulders Adam",

--- a/src/halls.json
+++ b/src/halls.json
@@ -6,7 +6,9 @@
     "latitude": 53.2161148,
     "longitude": 6.536471,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Be Boulder",
@@ -15,16 +17,20 @@
     "latitude": 52.3395626,
     "longitude": 4.8418298,
     "visited": true,
-    "rating": 2
+    "rating": 2,
+    "closed": true,
+    "geocodeSource": "manual"
   },
   {
-    "name": "Beest Boulders Amsterdam",
+    "name": "Beest Boulders Adam",
     "city": "Amsterdam",
     "province": "Noord-Holland",
     "latitude": 52.3812736,
     "longitude": 4.8596409,
     "visited": true,
-    "rating": 9
+    "rating": 9,
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Beest Boulders Breda",
@@ -33,7 +39,9 @@
     "latitude": 51.5949122,
     "longitude": 4.7551966,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Beest Boulders Den Haag HS",
@@ -42,7 +50,9 @@
     "latitude": 52.069385,
     "longitude": 4.3209697,
     "visited": true,
-    "rating": 6
+    "rating": 6,
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Beest Boulders Den Haag Centrum",
@@ -51,16 +61,20 @@
     "latitude": 52.0763455,
     "longitude": 4.3084002,
     "visited": true,
-    "rating": 10
+    "rating": 10,
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
-    "name": "Beest Boulders Rotterdam",
+    "name": "Beest Boulders Rdam",
     "city": "Rotterdam",
     "province": "Zuid-Holland",
     "latitude": 51.9273953,
     "longitude": 4.4737071,
     "visited": true,
-    "rating": 6
+    "rating": 6,
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Beta Boulders",
@@ -69,7 +83,9 @@
     "latitude": 52.3442045,
     "longitude": 4.8534011,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Bossche Boulders",
@@ -78,34 +94,42 @@
     "latitude": 51.6959284,
     "longitude": 5.276932,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
-    "name": "Boulder Neoliet Rotterdam",
+    "name": "Boulder Rotterdam",
     "city": "Rotterdam",
     "province": "Zuid-Holland",
     "latitude": 51.9083491,
     "longitude": 4.4312261,
     "visited": true,
-    "rating": 8
+    "rating": 8,
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
-    "name": "Boulder Neoliet Tilburg",
+    "name": "Boulder Tilburg",
     "city": "Tilburg",
     "province": "Noord-Brabant",
     "latitude": 51.5657197,
     "longitude": 5.1113669,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
-    "name": "Boulder Neoliet Veldhoven",
+    "name": "Boulder Veldhoven",
     "city": "Veldhoven",
     "province": "Noord-Brabant",
     "latitude": 51.4251821,
     "longitude": 5.4149687,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Bouldercentrum Delfts Bleau",
@@ -114,7 +138,9 @@
     "latitude": 51.9948255,
     "longitude": 4.3642833,
     "visited": true,
-    "rating": 8
+    "rating": 8,
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Bouldergym BAZ",
@@ -123,7 +149,9 @@
     "latitude": 52.4606986,
     "longitude": 4.8125532,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderhal Block013",
@@ -132,7 +160,9 @@
     "latitude": 51.5771628,
     "longitude": 5.0910545,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderhal Bruut",
@@ -141,7 +171,9 @@
     "latitude": 51.5981948,
     "longitude": 4.755504,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderhal de Campus",
@@ -150,7 +182,9 @@
     "latitude": 52.0495514,
     "longitude": 4.2546388,
     "visited": true,
-    "rating": 8
+    "rating": 8,
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderhal de Fabriek Haarlem",
@@ -159,7 +193,9 @@
     "latitude": 52.3919867,
     "longitude": 4.6470941,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderhal de Fabriek Hoofddorp",
@@ -168,7 +204,9 @@
     "latitude": 52.3135598,
     "longitude": 4.6908056,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderhal Energiehaven",
@@ -177,7 +215,9 @@
     "latitude": 52.1001073,
     "longitude": 5.0700532,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderhal Krachtstof",
@@ -186,7 +226,9 @@
     "latitude": 52.1585093,
     "longitude": 4.5115171,
     "visited": true,
-    "rating": 6
+    "rating": 6,
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderhal Kunststof",
@@ -195,7 +237,9 @@
     "latitude": 52.1450956,
     "longitude": 4.4809743,
     "visited": true,
-    "rating": "4"
+    "rating": "4",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderhal Roest",
@@ -204,7 +248,9 @@
     "latitude": 52.4986099,
     "longitude": 6.1188089,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderhal Sendmast",
@@ -213,7 +259,9 @@
     "latitude": 52.6172431,
     "longitude": 4.7669382,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderhal Sterk",
@@ -222,7 +270,9 @@
     "latitude": 52.0763815,
     "longitude": 5.1076692,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderhal Sterk Spoor",
@@ -231,7 +281,9 @@
     "latitude": 52.1050626,
     "longitude": 5.0820494,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderhal Walhalla",
@@ -240,7 +292,9 @@
     "latitude": 52.0616992,
     "longitude": 4.3136623,
     "visited": true,
-    "rating": 5
+    "rating": 5,
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderhal Zuidhaven",
@@ -249,7 +303,9 @@
     "latitude": 52.0645761,
     "longitude": 5.1039478,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderkerk Venlo",
@@ -258,7 +314,9 @@
     "latitude": 51.3567031,
     "longitude": 6.183003,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Boulderstation",
@@ -267,7 +325,9 @@
     "latitude": 52.2233143,
     "longitude": 6.8729603,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Cube Bouldergym",
@@ -276,7 +336,9 @@
     "latitude": 52.2230274,
     "longitude": 6.9033653,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Grip Boulderhal",
@@ -285,7 +347,9 @@
     "latitude": 51.8127732,
     "longitude": 5.8369825,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Gropo Bouldergym",
@@ -294,16 +358,20 @@
     "latitude": 53.2308935,
     "longitude": 6.5888408,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
-    "name": "Beest Boulders Het Lab",
+    "name": "Het Lab",
     "city": "Amsterdam",
     "province": "Noord-Holland",
     "latitude": 52.3923803,
     "longitude": 4.8508788,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Impact Boulderhal",
@@ -312,7 +380,9 @@
     "latitude": 52.3759045,
     "longitude": 5.2378009,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Kei Boulderhal",
@@ -321,7 +391,9 @@
     "latitude": 52.156822,
     "longitude": 5.3644533,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Kei Boulderhal De Hoef",
@@ -330,7 +402,9 @@
     "latitude": 52.1801889,
     "longitude": 5.414364,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Monk Amsterdam",
@@ -339,7 +413,9 @@
     "latitude": 52.383716,
     "longitude": 4.9285531,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Monk Eindhoven",
@@ -348,7 +424,9 @@
     "latitude": 51.4434507,
     "longitude": 5.4582798,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Monk Hilversum",
@@ -357,7 +435,9 @@
     "latitude": 52.2197772,
     "longitude": 5.1488591,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Monk Rotterdam",
@@ -366,7 +446,9 @@
     "latitude": 51.9418064,
     "longitude": 4.4728726,
     "visited": true,
-    "rating": 7
+    "rating": 7,
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Radium Boulders",
@@ -375,7 +457,9 @@
     "latitude": 50.8567614,
     "longitude": 5.6823573,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Revolt Boulderhal",
@@ -384,7 +468,9 @@
     "latitude": 52.0255472,
     "longitude": 4.3639055,
     "visited": true,
-    "rating": 8
+    "rating": 8,
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "RijnBoulder",
@@ -393,7 +479,9 @@
     "latitude": 51.9627664,
     "longitude": 5.9008776,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "The Climbing Corner",
@@ -402,7 +490,9 @@
     "latitude": 50.8955532,
     "longitude": 5.9562035,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
   },
   {
     "name": "Wildflower Climbing Gym",
@@ -411,6 +501,107 @@
     "latitude": 52.1593692,
     "longitude": 4.5136562,
     "visited": false,
-    "rating": "N/A"
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "manual"
+  },
+  {
+    "name": "Boulder Apeldoorn",
+    "city": "Apeldoorn",
+    "province": "Gelderland",
+    "latitude": 52.1927875,
+    "longitude": 5.9632354,
+    "visited": false,
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "nominatim"
+  },
+  {
+    "name": "Boulder Amsterdam",
+    "city": "Amsterdam",
+    "province": "Noord-Holland",
+    "latitude": 52.3764475,
+    "longitude": 4.8713885,
+    "visited": false,
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "nominatim"
+  },
+  {
+    "name": "Boulderwijk",
+    "city": "Beverwijk",
+    "province": "Noord-Holland",
+    "latitude": 52.4803827,
+    "longitude": 4.6653058,
+    "visited": false,
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "nominatim"
+  },
+  {
+    "name": "Beest Boulders Delft",
+    "city": "Delft",
+    "province": "Zuid-Holland",
+    "latitude": 52.0114017,
+    "longitude": 4.35839,
+    "visited": false,
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "city-fallback"
+  },
+  {
+    "name": "Boulderhal Vrijhaven",
+    "city": "Deventer",
+    "province": "Overijssel",
+    "latitude": 52.2475792,
+    "longitude": 6.1726075,
+    "visited": false,
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "nominatim"
+  },
+  {
+    "name": "Mono Boulder",
+    "city": "Ede",
+    "province": "Gelderland",
+    "latitude": 52.020782,
+    "longitude": 5.6673596,
+    "visited": false,
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "nominatim"
+  },
+  {
+    "name": "Silk Bouldergym",
+    "city": "Ede",
+    "province": "Gelderland",
+    "latitude": 52.0716826,
+    "longitude": 5.7455106,
+    "visited": false,
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "city-fallback"
+  },
+  {
+    "name": "Boulder Eindhoven",
+    "city": "Eindhoven",
+    "province": "Noord-Brabant",
+    "latitude": 51.4752471,
+    "longitude": 5.455758,
+    "visited": false,
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "nominatim"
+  },
+  {
+    "name": "Nirvana",
+    "city": "Scheveningen",
+    "province": "Zuid-Holland",
+    "latitude": 52.1100671,
+    "longitude": 4.2836164,
+    "visited": false,
+    "rating": "N/A",
+    "closed": false,
+    "geocodeSource": "nominatim"
   }
 ]

--- a/src/index.css
+++ b/src/index.css
@@ -9,8 +9,16 @@ body {
 
 /* ── Site header ──────────────────────────────────────────────── */
 .site-header {
+  position: relative;
   padding: 2.5rem 0 1.5rem;
   text-align: center;
+}
+
+.theme-toggle {
+  position: absolute;
+  top: 1.5rem;
+  right: 0;
+  padding: 0.4rem 0.7rem;
 }
 
 .site-title {
@@ -74,11 +82,6 @@ body {
 [data-bs-theme="dark"] .btn-outline-success {
   border-color: #4ade80 !important;
   color: #4ade80 !important;
-}
-
-.btn-warning {
-  background-color: #c47a0c !important;
-  color: #fff !important;
 }
 
 .btn-outline-secondary {
@@ -146,23 +149,25 @@ body {
   background: var(--bs-secondary-bg) !important;
   color: var(--bs-emphasis-color) !important;
   border-bottom: 2px solid var(--bs-border-color) !important;
-  padding: 0.75rem 1rem;
-  font-size: 0;
+  padding: 0.25rem 0.5rem;
   vertical-align: middle;
 }
 
-/* Sort buttons inside <th> look like plain text, not buttons */
+/* Sort buttons inside <th> — same padding/alignment as td cells */
 .table thead th .btn {
   background: transparent !important;
   color: var(--bs-emphasis-color) !important;
   border: none !important;
-  padding: 0.2rem 0.5rem;
+  padding: 0.45rem 0.5rem;
   font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.07em;
   border-radius: 6px !important;
   transition: background 0.12s;
+  display: block;
+  width: 100%;
+  text-align: left;
 }
 
 .table thead th .btn:hover {

--- a/src/index.css
+++ b/src/index.css
@@ -22,13 +22,13 @@ body {
 
 .site-subtitle {
   font-size: 0.9rem;
-  opacity: 0.55;
+  color: var(--bs-secondary-color);
   margin: 0;
 }
 
 .site-subtitle strong {
   color: #2f7531;
-  opacity: 1;
+  font-weight: 700;
 }
 
 /* ── Buttons ──────────────────────────────────────────────────── */
@@ -63,6 +63,17 @@ body {
 .btn-success {
   background-color: #2a6f2d !important;
   color: #fff !important;
+}
+
+.btn-outline-success {
+  background: transparent !important;
+  border: 1.5px solid #2a6f2d !important;
+  color: #2a6f2d !important;
+}
+
+[data-bs-theme="dark"] .btn-outline-success {
+  border-color: #4ade80 !important;
+  color: #4ade80 !important;
 }
 
 .btn-warning {

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,176 @@
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+/* ── Site header ──────────────────────────────────────────────── */
+.site-header {
+  padding: 2.5rem 0 1.5rem;
+  text-align: center;
+}
+
+.site-title {
+  font-size: clamp(1.8rem, 5vw, 2.6rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin: 0 0 0.4rem;
+}
+
+.site-subtitle {
+  font-size: 0.9rem;
+  opacity: 0.55;
+  margin: 0;
+}
+
+.site-subtitle strong {
+  color: #2f7531;
+  opacity: 1;
+}
+
+/* ── Buttons ──────────────────────────────────────────────────── */
+.btn {
+  border-radius: 999px !important;
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 0.42rem 1rem;
+  border: none !important;
+  box-shadow: none !important;
+  transition: opacity 0.15s ease, transform 0.1s ease;
+  white-space: nowrap;
+}
+
+.btn:not(.disabled):not(:disabled):hover {
+  opacity: 0.82;
+  transform: translateY(-1px);
+}
+
+.btn:not(.disabled):not(:disabled):active {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.btn-info {
+  background: var(--bs-secondary-bg) !important;
+  color: var(--bs-secondary-color) !important;
+  cursor: default !important;
+  pointer-events: none;
+}
+
+.btn-success {
+  background-color: #2a6f2d !important;
+  color: #fff !important;
+}
+
+.btn-warning {
+  background-color: #c47a0c !important;
+  color: #fff !important;
+}
+
+.btn-outline-secondary {
+  background: transparent !important;
+  border: 1.5px solid var(--bs-border-color) !important;
+  color: var(--bs-body-color) !important;
+}
+
+.btn-outline-secondary:hover {
+  background: var(--bs-secondary-bg) !important;
+}
+
+.btn-outline-secondary.active {
+  background: var(--bs-secondary-bg) !important;
+}
+
+/* ── Search / filter bar ──────────────────────────────────────── */
+.filter-bar {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.filter-bar .form-control {
+  border-radius: 999px !important;
+  border: 1.5px solid var(--bs-border-color);
+  background: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  padding: 0.42rem 1rem;
+  flex: 1 1 140px;
+  min-width: 0;
+  font-size: 0.85rem;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.filter-bar .form-control:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.filter-bar .form-control::placeholder {
+  opacity: 0.45;
+}
+
+/* ── Table ────────────────────────────────────────────────────── */
+.table-responsive {
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  border: 1px solid var(--bs-border-color);
+}
+
+.table {
+  margin-bottom: 0;
+}
+
+.table > :not(caption) > * > * {
+  border-color: var(--bs-border-color) !important;
+}
+
+.table thead th {
+  background: var(--bs-secondary-bg) !important;
+  color: var(--bs-emphasis-color) !important;
+  border-bottom: 2px solid var(--bs-border-color) !important;
+  padding: 0.75rem 1rem;
+  font-size: 0;
+  vertical-align: middle;
+}
+
+/* Sort buttons inside <th> look like plain text, not buttons */
+.table thead th .btn {
+  background: transparent !important;
+  color: var(--bs-emphasis-color) !important;
+  border: none !important;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  border-radius: 6px !important;
+  transition: background 0.12s;
+}
+
+.table thead th .btn:hover {
+  background: var(--bs-border-color) !important;
+  transform: none;
+  opacity: 1;
+}
+
+.table td {
+  padding: 0.7rem 1rem;
+  vertical-align: middle;
+  font-size: 0.88rem;
+}
+
+/* ── Map wrapper ──────────────────────────────────────────────── */
+.map-wrapper {
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 1rem;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
+  border: 1px solid var(--bs-border-color);
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,21 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Replaces the static halls.json with a fully automated pipeline and upgrades the map from Leaflet/OpenStreetMap to the Google Maps JS API.

## Automation
- `scripts/update-halls.js` — weekly scraper that diffs pofzak.nl against halls.json, geocodes new halls via Google Places API, and writes the result back. Planned/cancelled halls (keywords: gesloten, geannuleerd, on hold, onbekend, future year in name) are skipped automatically.
- `.github/workflows/update-halls.yml` — runs every Monday at 09:00 UTC, opens a PR with auto-merge enabled so Vercel's deploy check gates the merge.

## Geocoding
- New halls are geocoded via Google Places Text Search (GOOGLE_MAPS_API_KEY).
- Existing halls with imprecise coords (city-fallback/failed) are re-geocoded on the next script run once the key is set.
- Coordinates for existing halls are never overwritten (stable by design).
- Province values are not propagated from pofzak.nl — their data has errors.

## Closed hall tracking
- Halls that disappear from pofzak.nl get closed: true, preserving visited status and rating. They reopen automatically if they reappear.
- UI: closed halls hidden by default behind a toggle in the search bar.
- Closed halls show a gray row + "Gesloten" badge in the table, gray marker on the map.

## Map: Leaflet → Google Maps
- Replaced react-leaflet + leaflet with @vis.gl/react-google-maps.
- Custom colored circle markers: green = visited, blue = open, gray = closed, red = current location.
- InfoWindow popup on marker click showing hall name, city, closed status.
- Map pans to user location when geolocation is granted.

## Security
- vercel.json adds X-Frame-Options: DENY, X-Content-Type-Options, and Referrer-Policy headers to prevent API key misuse via iframe embedding.
- NEXT_PUBLIC_GOOGLE_MAPS_API_KEY should be restricted to HTTP referrers (your Vercel domain) in Google Cloud Console.